### PR TITLE
fix: standardize CreatorOs naming and documentation references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -67,4 +67,4 @@ Fixes #
 
 ---
 
-**Thank you for contributing to CreatorOS!** 🙌
+**Thank you for contributing to CreatorOs!** 🙌

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# 🤝 Contributing to CreatorOS
+# 🤝 Contributing to CreatorOs
 
-Thank you for wanting to contribute to CreatorOS! We're excited to have you help build the future of creator tools.
+Thank you for wanting to contribute to CreatorOs! We're excited to have you help build the future of creator tools.
 
 ## 🚀 Quick Start
 
@@ -281,7 +281,7 @@ Real-world use cases:
 ### Post-Merge
 - Your changes will be deployed in the next release
 - You'll be credited as a contributor
-- Your code is now part of CreatorOS! 🎉
+- Your code is now part of CreatorOs! 🎉
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=180&section=header&text=CreaterOS&fontSize=72&fontColor=fff&animation=twinkling&fontAlignY=32&desc=The%20Operating%20System%20for%20Creators&descAlignY=56&descSize=20&descColor=ffffff" width="100%"/>
+<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=180&section=header&text=CreatorOs&fontSize=72&fontColor=fff&animation=twinkling&fontAlignY=32&desc=The%20Operating%20System%20for%20Creators&descAlignY=56&descSize=20&descColor=ffffff" width="100%"/>
 
 <br/>
 
@@ -51,11 +51,11 @@ Every creator knows this chaos:
 
 **That's 6+ apps, 6+ subscriptions, 6+ logins — just to run your creator business.**
 
-CreaterOS ends this. One platform. Everything connected. Zero context-switching.
+CreatorOs ends this. One platform. Everything connected. Zero context-switching.
 
 ---
 
-## ✨ What CreaterOS Does
+## ✨ What CreatorOs Does
 
 <table>
 <tr>
@@ -154,10 +154,10 @@ npm >= 9.0.0
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/crateros.git
+git clone https://github.com/yourusername/CreatorOs.git
 
 # Navigate into the project
-cd crateros
+cd CreatorOs
 
 # Install dependencies
 npm install
@@ -204,7 +204,7 @@ open http://localhost:3000
 ## 📁 Project Structure
 
 ```
-crateros/
+CreatorOs/
 ├── 📂 app/                    # Next.js App Router
 │   ├── 📂 (auth)/             # Auth pages (login, signup)
 │   ├── 📂 (dashboard)/        # Main dashboard routes
@@ -233,7 +233,7 @@ crateros/
 
 </div>
 
-If you're building an audience and monetizing your knowledge — CreaterOS is your control center.
+If you're building an audience and monetizing your knowledge — CreatorOs is your control center.
 
 ---
 
@@ -346,7 +346,7 @@ Every contribution, no matter how small, helps us build something amazing for cr
 
 <br/>
 
-*If CreaterOS saves you time, give it a ⭐ — it means the world.*
+*If CreatorOs saves you time, give it a ⭐ — it means the world.*
 
 <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=6,11,20&height=100&section=footer" width="100%"/>
 


### PR DESCRIPTION
## Description

This PR resolves multiple documentation and project structure inconsistencies that were causing contributor confusion during onboarding.

### Changes Made

#### README.md

* Standardized all incorrect repository name variations:

  * `CreaterOS` → `CreatorOs`
  * `crateros` → `CreatorOs`
  * `CreatorOS` → `CreatorOs`
* Fixed incorrect clone URL:

  * `crateros.git` → `CreatorOs.git`
* Updated navigation/setup commands:

  * `cd crateros` → `cd CreatorOs`
* Corrected project structure references for consistency
* Updated branding text and section headings throughout the README

#### CONTRIBUTING.md

* Standardized all repository naming references to `CreatorOs`
* Updated contributor onboarding text for consistency

#### .github/pull_request_template.md

* Fixed inconsistent repository branding references

---

## Benefits

* Improves contributor onboarding experience
* Eliminates confusion caused by inconsistent repository naming
* Ensures setup instructions and clone commands are accurate
* Maintains consistent repository branding across documentation
* Makes the project more beginner-friendly during GSSoC 2026

---

## Testing

* Verified all repository references now consistently use `CreatorOs`
* Checked clone/setup commands for correctness
* Confirmed documentation formatting and structure remain intact

Closes #17 