### PR TITLE
feat: add contributor login shortcut

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -1,10 +1,35 @@
 const User = require("../model/user");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
+
+const CONTRIBUTOR_EMAIL = "contributor@creatoros.local";
+const CONTRIBUTOR_NAME = "Contributor";
 
 function wantsHtml(req) {
     const accept = req.headers.accept || '';
     return accept.includes('text/html');
+}
+
+function createToken(userId) {
+    return jwt.sign(
+        {
+            id: userId,
+        },
+        process.env.JWT_SECRET,
+        {
+            expiresIn: '7d',
+        }
+    );
+}
+
+function setAuthCookie(res, token) {
+    res.cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
 }
 
 const signup = async (req, res, next) => {
@@ -41,7 +66,6 @@ const login = async (req, res, next) => {
 
         const user = await User.findOne({ email });
 
-        // Generic message to prevent user enumeration
         const genericMessage = 'Invalid email or password';
 
         if (!user) {
@@ -56,23 +80,9 @@ const login = async (req, res, next) => {
             return res.status(401).json({ success: false, message: genericMessage });
         }
 
-        const token = jwt.sign(
-            {
-                id: user._id,
-            },
-            process.env.JWT_SECRET,
-            {
-                expiresIn: '7d',
-            }
-        );
+        const token = createToken(user._id);
 
-        // set secure cookie flags
-        res.cookie('token', token, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production',
-            sameSite: 'strict',
-            maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-        });
+        setAuthCookie(res, token);
 
         if (wantsHtml(req)) return res.redirect('/dashboard');
         return res.status(200).json({ success: true, message: 'Authenticated' });
@@ -81,7 +91,34 @@ const login = async (req, res, next) => {
     }
 };
 
+const loginAsContributor = async (req, res, next) => {
+    try {
+        let user = await User.findOne({ email: CONTRIBUTOR_EMAIL });
+
+        if (!user) {
+            const randomPassword = crypto.randomUUID();
+            const hashedPassword = await bcrypt.hash(randomPassword, 10);
+
+            user = await User.create({
+                name: CONTRIBUTOR_NAME,
+                email: CONTRIBUTOR_EMAIL,
+                password: hashedPassword,
+            });
+        }
+
+        const token = createToken(user._id);
+
+        setAuthCookie(res, token);
+
+        if (wantsHtml(req)) return res.redirect('/dashboard');
+        return res.status(200).json({ success: true, message: 'Authenticated as contributor' });
+    } catch (error) {
+        next(error);
+    }
+};
+
 module.exports = {
     signup,
     login,
+    loginAsContributor,
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 
-const { signup, login } = require("../controller/auth");
+const { signup, login, loginAsContributor } = require("../controller/auth");
 const { signupValidator, loginValidator } = require("../middleware/validateAuth");
 
 router.get("/signup", (req, res) => {
@@ -15,6 +15,8 @@ router.get("/login", (req, res) => {
 router.post("/signup", signupValidator, signup);
 
 router.post("/login", loginValidator, login);
+
+router.post("/login/contributor", loginAsContributor);
 
 router.get("/logout", (req, res) => {
     res.clearCookie("token");

--- a/view/login.ejs
+++ b/view/login.ejs
@@ -174,6 +174,23 @@
         .switch-link a:hover {
             color: #a5f3fc;
         }
+
+        .contributor-form {
+            margin-top: 1rem;
+        }
+
+        .contributor-btn {
+            width: 100%;
+            color: var(--text);
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(148, 163, 184, 0.22);
+            box-shadow: none;
+        }
+
+        .contributor-btn:hover {
+            background: rgba(34, 211, 238, 0.12);
+            transform: translateY(-2px);
+        }
     </style>
 </head>
 <body>
@@ -191,6 +208,10 @@
                 <input type="email" name="email" placeholder="Email" required>
                 <input type="password" name="password" placeholder="Password" required>
                 <button type="submit">Login</button>
+            </form>
+
+            <form action="/login/contributor" method="POST" class="contributor-form">
+                <button type="submit" class="contributor-btn">Login as Contributor</button>
             </form>
 
             <p class="switch-link">


### PR DESCRIPTION
## 📝 Description
  Adds an enhanced contributor login flow to CreatorOS. Contributors can now log in from the login page
  without entering an email or password, using a dedicated "Login as Contributor" button.

  The implementation reuses the existing JWT cookie authentication flow and redirects contributors to the
  dashboard, so existing protected routes continue to work normally.

  ## 🔗 Related Issues

  Fixes #21

  ## 📋 Type of Change

  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] 📚 Documentation update
  - [x] ♻️ Code refactoring
  - [ ] 🎨 Style changes
  - [ ] ⚡ Performance improvement
  - [ ] 🧪 Test update

  ## 🔄 Changes Made

  - Added a separate "Login as Contributor" button on the login page
  - Added a dedicated `POST /login/contributor` route
  - Added contributor login controller logic that creates or reuses one stable contributor user
  - Reused the existing JWT cookie auth flow for contributor sessions
  - Cleaned up duplicate auth controller exports
  - Moved auth route export to the bottom of the route file for cleaner structure

  ## ✅ Testing

  ### How to Test

  1. Start the app:
     ```bash
     npm run dev

  2. Open:

     http://localhost:3000/login

  3. Click Login as Contributor and verify it redirects to /dashboard.
  4. Verify protected routes work after contributor login:

     /dashboard
     /profile
     /services/url-shortener
     /suggestions

  5. Visit /logout and confirm protected routes redirect back to /login.
  6. Confirm normal email/password login still works.

  ### Test Coverage

  Manual syntax verification completed:

  - node --check index.js
  - node --check controller/auth.js
  - node --check routes/auth.js

  ## 📸 Screenshots (if applicable)

<img width="1223" height="976" alt="image" src="https://github.com/user-attachments/assets/4a009b1d-1c50-40b3-8d19-05fdd6bb3929" />


  ## 🚀 Deployment Notes

  No special deployment steps required.

  The contributor login uses the existing MongoDB user model and JWT cookie auth flow.

  ## ⚠️ Breaking Changes

  - None

  ## 📋 Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have self-reviewed my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix/feature works
  - [ ] New and existing unit tests pass locally with my changes
  - [x] My PR title follows the naming convention
  - [x] I have linked related issues

  ## 📝 Additional Context

  Contributor login creates or reuses a stable contributor account internally, then signs in through the
  same JWT cookie flow used by normal login. This keeps dashboard and protected route behavior unchanged.
  
*Tested with the env fix for #29 pls merge #29 befro merging this 