### PR TITLE
Fix: Display auth validation errors in UI instead of raw JSON dump (Resolves #55)

### DIFF
--- a/middleware/validateAuth.js
+++ b/middleware/validateAuth.js
@@ -11,7 +11,7 @@ const loginSchema = z.object({
   password: z.string().min(1, 'Password is required'),
 });
 
-function validate(schema) {
+function validate(schema, viewName) {
   return (req, res, next) => {
     try {
       // parse will throw if invalid
@@ -19,12 +19,21 @@ function validate(schema) {
       return next();
     } catch (err) {
       const errors = (err.errors || []).map((e) => ({ path: e.path.join('.'), message: e.message }));
+      
+      const wantsHtml = req.headers.accept && req.headers.accept.includes('text/html');
+      
+      if (wantsHtml && viewName) {
+        // Use the first validation error as the friendly error message
+        const errorMessage = errors.length > 0 ? errors[0].message : 'Invalid request data';
+        return res.status(400).render(viewName, { error: errorMessage });
+      }
+
       return res.status(400).json({ success: false, message: 'Invalid request data', errors });
     }
   };
 }
 
 module.exports = {
-  signupValidator: validate(signupSchema),
-  loginValidator: validate(loginSchema),
+  signupValidator: validate(signupSchema, 'signup'),
+  loginValidator: validate(loginSchema, 'login'),
 };

--- a/view/login.ejs
+++ b/view/login.ejs
@@ -187,9 +187,15 @@
             box-shadow: none;
         }
 
-        .contributor-btn:hover {
-            background: rgba(34, 211, 238, 0.12);
-            transform: translateY(-2px);
+        .error-banner {
+            background: rgba(239, 68, 68, 0.15);
+            color: #fca5a5;
+            border: 1px solid rgba(239, 68, 68, 0.3);
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            margin-bottom: 1rem;
+            font-size: 0.9rem;
+            text-align: center;
         }
     </style>
 </head>
@@ -203,6 +209,12 @@
 
             <h1>Welcome back</h1>
             <p class="subtitle">Log in to continue managing your creator tools and shortened links.</p>
+
+            <% if (typeof error !== 'undefined' && error) { %>
+                <div class="error-banner">
+                    <%= error %>
+                </div>
+            <% } %>
 
             <form action="/login" method="POST">
                 <input type="email" name="email" placeholder="Email" required>

--- a/view/signup.ejs
+++ b/view/signup.ejs
@@ -171,8 +171,15 @@
             text-decoration: none;
         }
 
-        .switch-link a:hover {
-            color: #a5f3fc;
+        .error-banner {
+            background: rgba(239, 68, 68, 0.15);
+            color: #fca5a5;
+            border: 1px solid rgba(239, 68, 68, 0.3);
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            margin-bottom: 1rem;
+            font-size: 0.9rem;
+            text-align: center;
         }
     </style>
 </head>
@@ -186,6 +193,12 @@
 
             <h1>Create account</h1>
             <p class="subtitle">Join CreatorOS and start using the creator tools built for fast, clean workflows.</p>
+
+            <% if (typeof error !== 'undefined' && error) { %>
+                <div class="error-banner">
+                    <%= error %>
+                </div>
+            <% } %>
 
             <form action="/signup" method="POST">
                 <input type="text" name="name" placeholder="Name" required>


### PR DESCRIPTION
## Description
This PR resolves an issue where submitting invalid data (e.g., an invalid email format or short password) on the `/login` or `/signup` HTML forms would result in the user's browser rendering a raw `400 Bad Request` JSON payload from the Zod validation middleware. 

Additionally, it was discovered that the frontend EJS templates completely lacked the logic to render error variables passed down from the backend. 

## Resolved Issue
Resolves #55 

**Changes included:**
1. **Middleware Update:** `middleware/validateAuth.js` now respects the `Accept: text/html` header. If an HTML request fails validation, it extracts the primary Zod error message and uses `res.render` to return the user to the form.
2. **UI Update:** Added a styled `.error-banner` component to both `view/login.ejs` and `view/signup.ejs` to ensure validation errors and backend auth errors (like "Invalid password") are visibly rendered above the forms.

## Demo / Test Explanation
To verify this fix, I ran the application server locally and attempted to bypass client-side validation by submitting improperly formatted data directly via the browser. 
- **Before:** The browser navigated to a blank screen dumping `{"success": false, "errors": [...]}`.
- **After:** The form reloads perfectly, preserving the UI, and displays a red error banner with a user-friendly message (e.g., "Password must be at least 8 characters").

### Screen Recording


https://github.com/user-attachments/assets/29ddf22e-fbd3-486b-96de-b5d2a2fbeef9



