### PR TITLE
Fix: Prevent orphaned invites on email failure (Resolves #58)

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -65,13 +65,18 @@ const sendCollaboratorInvite = async (req, res, next) => {
     const inviteUrl = `${process.env.APP_URL || `${req.protocol}://${req.get('host')}`}/invites/accept/${token}`;
     const userDoc = await User.findById(req.user.id).select('name email').lean();
 
-    await sendInvitationEmail({
-      to: invite.email,
-      inviterName: userDoc?.name || 'CreatorOS',
-      projectName: invite.projectName,
-      inviteUrl,
-      personalMessage: invite.message,
-    });
+    try {
+      await sendInvitationEmail({
+        to: invite.email,
+        inviterName: userDoc?.name || 'CreatorOS',
+        projectName: invite.projectName,
+        inviteUrl,
+        personalMessage: invite.message,
+      });
+    } catch (emailError) {
+      await Invite.findByIdAndDelete(invite._id);
+      throw emailError;
+    }
 
     const invites = await Invite.find({ inviter: req.user.id }).sort({ createdAt: -1 }).limit(12).lean();
     res.render('creator-crm', {


### PR DESCRIPTION
## Description
This PR resolves an issue where failing to send a collaboration invitation email would leave an active, stranded invite token in the database. 

## Resolved Issue
Resolves #58 

**Changes included:**
- **Database Consistency:** In `controller/collaborationController.js`, the `sendCollaboratorInvite` function now wraps the email dispatch in a try-catch block. If the email fails to send (e.g., due to SMTP timeout or invalid configuration), `Invite.findByIdAndDelete()` is called to rollback the transaction and remove the orphaned invite before bubbling the error up to the UI.

## Demo / Test Explanation
To verify this fix, I triggered an intentional email dispatch failure by removing the SMTP configuration from the environment variables. 
- I logged into the app and navigated to the Creator CRM page to submit the invite form.
- **Before:** The UI would display an error, but the invite would still be created and sit in the database forever as "pending".
- **After:** The app cleanly catches the email configuration error, displays it on the UI, and the "Recent Invites" list on the dashboard remains perfectly empty, proving the database transaction was successfully rolled back.

### Screen Recording


https://github.com/user-attachments/assets/4d283da5-6953-42b2-9fa7-9188d5d62e03


