### PR TITLE
Add prefers-reduced-motion support to dashboard hover effects for accessibility

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -8,3 +8,15 @@
     transform: translateY(-4px);
     box-shadow: 6px 6px 0 rgba(0,0,0,0.12);
 }
+
+@media (prefers-reduced-motion: reduce) {
+    .stat-card-retro,
+    .panel-retro {
+        transition: none;
+    }
+    
+    .stat-card-retro:hover,
+    .panel-retro:hover {
+        transform: none;
+    }
+}


### PR DESCRIPTION
## Description

Add a @media (prefers-reduced-motion: reduce) query to public/css/dashboard.css to respect user accessibility preferences. When users have "Reduce motion" enabled in their system settings, hover animations on stat cards and panels will be disabled.

### Changes
- Added @media (prefers-reduced-motion: reduce) block in dashboard.css
- Disables transitions and hover transforms when reduced motion is preferred

Closes #183

Mentions: gssoc26