### PR TITLE
Add hover transition to coming-soon page back link

### DIFF
--- a/view/coming-soon.ejs
+++ b/view/coming-soon.ejs
@@ -65,6 +65,11 @@
             font-weight: 700;
             border-radius: 10px;
             padding: 0.65rem 0.9rem;
+            transition: background 0.2s ease;
+        }
+
+        a:hover {
+            background: #06b6d4;
         }
     </style>
 </head>


### PR DESCRIPTION
## Description

Add a smooth background color transition on hover for the Back to service hub link in the coming-soon view, improving visual feedback and UX polish.

### Changes
- Added transition: background 0.2s ease to the link
- Added :hover state with darker cyan background (#06b6d4)

Closes #185

Mentions: gssoc26