### PR TITLE
Add type=button to nav toggle buttons for HTML best practice

### DIFF
--- a/view/services-hub.ejs
+++ b/view/services-hub.ejs
@@ -2218,7 +2218,7 @@ footer span { color: var(--cyan); }
 
         <div class="nav-left">
 
-          <button class="nav-toggle" id="navToggle" aria-label="Open menu">☰</button>
+          <button type="button" class="nav-toggle" id="navToggle" aria-label="Open menu">☰</button>
 
           <a class="brand" href="/">
 
@@ -2246,7 +2246,7 @@ footer span { color: var(--cyan); }
 
           </div>
 
-          <button class="nav-3d-toggle" id="nav3dToggle" aria-pressed="true" title="Toggle 3D Background">3D</button>
+          <button type="button" class="nav-3d-toggle" id="nav3dToggle" aria-pressed="true" title="Toggle 3D Background">3D</button>
 
         </div>
 


### PR DESCRIPTION
## Description

Add explicit type=button to nav-toggle and nav-3d-toggle buttons in services-hub.ejs to prevent accidental form submissions. This is an HTML best practice for buttons that do not submit forms.

### Changes
- Added type=button to nav-toggle button
- Added type=button to nav-3d-toggle button

Closes #187

Mentions: gssoc26