### PR TITLE
Add rel=noopener noreferrer to external link for security

### DIFF
--- a/view/home.ejs
+++ b/view/home.ejs
@@ -1552,7 +1552,7 @@
                                         <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.1-1.1m-.758-4.9a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
                                         </svg>
-                                        <a href="<%= shortUrl %>" target="_blank" style="color:inherit; text-decoration:none;"><%= shortUrl %></a>
+                                        <a href="<%= shortUrl %>" target="_blank" rel="noopener noreferrer" style="color:inherit; text-decoration:none;"><%= shortUrl %></a>
                                     </div>
                                     <button type="button" class="btn-copy" onclick="copyToClipboard('<%= shortUrl %>')" style="background:var(--bg-secondary); color:var(--text); border:2px solid var(--border); padding:0.75rem 1.5rem; font-weight:700; cursor:pointer; box-shadow:2px 2px 0px var(--border); transition:all 0.1s;">Copy</button>
                                 </div>


### PR DESCRIPTION
## Description

Add rel=noopener noreferrer to the target=_blank link in home.ejs to prevent security vulnerability where the opened page can access window.opener.

### Changes
- Added rel=noopener noreferrer to the shortened URL link that opens in a new tab

Closes #189

Mentions: gssoc26