### PR TITLE
Fix CreatorOS capitalization inconsistency in SEO og:site_name

### DIFF
--- a/view/partials/_seo.ejs
+++ b/view/partials/_seo.ejs
@@ -6,7 +6,7 @@
 <meta property="og:title" content="<%= title %>">
 <meta property="og:description" content="<%= description %>">
 <meta property="og:url" content="<%= canonical %>">
-<meta property="og:site_name" content="CreatorOs">
+<meta property="og:site_name" content="CreatorOS">
 <meta property="og:image" content="https://titli-link-shortner.vercel.app/android-chrome-512x512.png">
 
 <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## Description

Fix capitalization inconsistency in the SEO partial where og:site_name uses CreatorOs (lowercase s) while the title tag uses CreatorOS (all caps).

### Changes
- Changed og:site_name from CreatorOs to CreatorOS for consistency

Closes #191

Mentions: gssoc26