### PR TITLE
feat: add scroll to top button to dashboard layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,8 +1131,7 @@
       "version": "0.0.1624250",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
       "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",

--- a/view/partials/dashboard/_scripts.ejs
+++ b/view/partials/dashboard/_scripts.ejs
@@ -33,4 +33,33 @@
       toggleBtn.innerText = '☀️';
     }
   });
+  document.addEventListener("DOMContentLoaded", () => {
+  const btn = document.getElementById('scrollToTopBtn');
+  if (!btn) return;
+
+  // 1. Global Interception to watch scrolls inside dashboardLayout panels
+  window.addEventListener('scroll', (e) => {
+    const scrollPos = e.target.scrollTop || window.scrollY || 0;
+    if (scrollPos > 300) {
+      btn.classList.add('show');
+    } else {
+      btn.classList.remove('show');
+    }
+  }, true); // 'true' enables event capturing to catch nested container scrolls
+
+  // 2. Global Execution to smooth scroll the wrapper components
+  btn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    
+    const layouts = [
+      document.getElementById('dashboardLayout'),
+      document.querySelector('.dashboard-layout'),
+      document.querySelector('main')
+    ];
+    
+    layouts.forEach(container => {
+      if (container) container.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  });
+});
 </script>

--- a/view/partials/dashboard/_styles.ejs
+++ b/view/partials/dashboard/_styles.ejs
@@ -380,4 +380,50 @@
     .legend { width: 100%; }
     .profile-name { display: none; }
   }
+  #scrollToTopBtn {
+  position: fixed !important;
+  bottom: 30px !important;
+  right: 30px !important;
+  z-index: 99999 !important;
+  width: 48px !important;
+  height: 48px !important;
+  background-color: var(--accent, #22d3ee) !important; 
+  color: #000000 !important;
+  border: 3px solid #000000 !important;
+  border-radius: 4px !important;
+  cursor: pointer !important;
+  box-shadow: 4px 4px 0px #000000 !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  padding: 0 !important;
+  
+  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  transition: transform 0.1s ease, opacity 0.2s ease, visibility 0.2s ease !important;
+}
+
+#scrollToTopBtn svg {
+  width: 24px !important;
+  height: 24px !important;
+  display: block !important;
+  stroke: #000000 !important;
+}
+
+#scrollToTopBtn:hover {
+  transform: translate(-2px, -2px) !important;
+  box-shadow: 6px 6px 0px #000000 !important;
+}
+
+#scrollToTopBtn:active {
+  transform: translate(4px, 4px) !important;
+  box-shadow: 0px 0px 0px #000000 !important;
+}
+
+/* Toggled on when layout container scrolls */
+#scrollToTopBtn.show {
+  opacity: 1 !important;
+  visibility: visible !important;
+}
 </style>

--- a/view/partials/dashboard/dashboard.ejs
+++ b/view/partials/dashboard/dashboard.ejs
@@ -50,5 +50,10 @@
   </div>
 
   <%- include('./partials/dashboard/_scripts') %>
+  <button id="scrollToTopBtn" aria-label="Scroll to top" title="Go to top">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="18 15 12 9 6 15"></polyline>
+  </svg>
+</button>
 </body>
 </html>


### PR DESCRIPTION
📝 Overview
This PR implements a functional, styled Scroll-to-Top button for the authenticated user dashboard. Because the dashboard layout contains a contained wrapper with local overflow (#dashboardLayout), standard window-scroll event listeners were failing to trigger. This solution hooks directly into the layout's scrolling context using event capturing.

🛠️ Changes Made
HTML (view/dashboard.ejs): Added a self-contained, semantic button with an inline SVG arrow indicator at the root layout level.

Styles (view/partials/dashboard/_styles.ejs): Implemented clean, accessible CSS rules applying a fixed layout placement, interactive hover/active scales, and toggle states via opacity/visibility classes.

JavaScript (view/partials/dashboard/_scripts.ejs): Added initialization logic utilizing event capturing (true) to reliably intercept scrolls inside nested layout panels and execute a smooth scroll behavior back to the top wrapper elements.

🧪 How to Test
Switch to your feature branch (git checkout feature/scroll-to-top).

Run the application locally in mock mode (npm run dev).

Navigate into the dashboard views (e.g., your lists or analytical tracking panels) and scroll down past 300px.

Verify that the button smoothly fades into view in the bottom-right corner.

Click the button and verify it smoothly returns the entire layout context back to the top.

closes #179 