### PR TITLE
Refactor: Standardize layout structure via EJS partials

### DIFF
--- a/scripts/replace-layout.js
+++ b/scripts/replace-layout.js
@@ -1,0 +1,209 @@
+const fs = require('fs');
+const path = require('path');
+
+const viewsDir = path.join(__dirname, '..', 'view');
+const partialsDir = path.join(viewsDir, 'partials', 'layout');
+
+if (!fs.existsSync(partialsDir)) {
+    fs.mkdirSync(partialsDir, { recursive: true });
+}
+
+// 1. Create the sidebar partial based on the extracted dashboard layout
+const sidebarContent = `<aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
+    <a class="brand" href="/dashboard">
+        <span class="brand-mark">CO</span>
+        <div>
+            <span class="brand-text">CreatorOS</span>
+            <span class="brand-version">v2.0 Beta</span>
+        </div>
+    </a>
+
+    <!-- Workspace section -->
+    <nav class="sidebar-section">
+        <p class="sidebar-label">Workspace</p>
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'dashboard' ? 'active' : '' %>" href="/dashboard">
+            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
+            <span class="nav-text">Dashboard</span>
+        </a>
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'my-links' ? 'active' : '' %>" href="/services/url-shortener">
+            <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
+            <span class="nav-text">My Links</span>
+        </a>
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'analytics' ? 'active' : '' %>" href="/services/analytics-dashboard">
+            <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
+            <span class="nav-text">Analytics</span>
+        </a>
+       
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'settings' ? 'active' : '' %>" href="/settings">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
+            <span class="nav-text">Settings</span>
+        </a>
+    </nav>
+
+    <!-- Services section -->
+    <nav class="sidebar-section" aria-label="Services">
+        <p class="sidebar-label">Services</p>
+        <% if (typeof services !== 'undefined' && services && services.length) { %>
+            <% services.forEach((service) => { %>
+                <a class="service-link <%= typeof activeNav !== 'undefined' && activeNav === service.route ? 'active' : '' %> <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
+                    <span class="service-name"><%= service.name %></span>
+                </a>
+            <% }) %>
+        <% } %>
+    </nav>
+
+    <div class="sidebar-footer" style="margin-top: auto;">
+        <div class="upgrade-box">
+            <h4>Upgrade Plan</h4>
+            <p style="font-size: 0.9rem;">Get access to advanced webhooks & APIs.</p>
+            <button class="upgrade-btn" type="button">Upgrade</button>
+        </div>
+        <a class="nav-link" href="/logout">
+            <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
+            <span class="nav-text">Logout</span>
+        </a>
+    </div>
+</aside>`;
+
+fs.writeFileSync(path.join(partialsDir, 'sidebar.ejs'), sidebarContent, 'utf8');
+
+// 2. Create the topbar partial
+const topbarContent = `<header class="topbar">
+    <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
+        <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
+    </button>
+
+    <div class="search-container">
+        <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+        <input type="text" id="search-links-input" class="search-input" placeholder="Search shortened links..." />
+    </div>
+
+    <div class="topbar-actions">
+        <button id="theme-toggle" class="action-icon-btn" type="button" aria-label="Toggle Theme">
+            <svg class="icon-light" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto;"><path d="M7.5 1.5V2.5M7.5 12.5V13.5M1.5 7.5H2.5M12.5 7.5H13.5M3.257 3.257L3.964 3.964M11.035 11.035L11.742 11.742M3.257 11.742L3.964 11.035M11.035 3.964L11.742 3.257" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/><circle cx="7.5" cy="7.5" r="2.75" stroke="currentColor" stroke-width="1.5"/></svg>
+            <svg class="icon-dark" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto; display:none;"><path d="M1.66 7.452C1.66 10.67 4.268 13.278 7.485 13.278C10.02 13.278 12.18 11.65 12.987 9.388C12.103 10.199 10.899 10.706 9.57 10.706C6.884 10.706 4.706 8.528 4.706 5.842C4.706 4.542 5.193 3.364 5.976 2.493C3.541 3.195 1.66 5.128 1.66 7.453Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
+        </button>
+        <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
+        <a class="profile-chip" href="/profile">
+            <span class="avatar"><%= typeof user !== 'undefined' ? user.initials : 'U' %></span>
+            <span class="profile-name"><%= typeof user !== 'undefined' ? user.name : 'User' %></span>
+        </a>
+        <a class="primary-action-btn" href="/services/url-shortener">
+            <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
+            Create Link
+        </a>
+    </div>
+</header>`;
+
+fs.writeFileSync(path.join(partialsDir, 'topbar.ejs'), topbarContent, 'utf8');
+
+// 3. Create scripts partial
+const scriptsContent = `<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // Theme Toggle Logic
+        const themeBtn = document.getElementById('theme-toggle');
+        const root = document.documentElement;
+        const iconLight = themeBtn ? themeBtn.querySelector('.icon-light') : null;
+        const iconDark = themeBtn ? themeBtn.querySelector('.icon-dark') : null;
+        
+        function applyTheme(isDark) {
+            if (isDark) {
+                root.setAttribute('data-theme', 'dark');
+                if (iconLight) iconLight.style.display = 'none';
+                if (iconDark) iconDark.style.display = 'block';
+            } else {
+                root.removeAttribute('data-theme');
+                if (iconLight) iconLight.style.display = 'block';
+                if (iconDark) iconDark.style.display = 'none';
+            }
+        }
+
+        if (themeBtn) {
+            if (localStorage.getItem('theme') === 'dark') {
+                applyTheme(true);
+            } else {
+                applyTheme(false);
+            }
+
+            themeBtn.addEventListener('click', () => {
+                const isDark = root.getAttribute('data-theme') === 'dark';
+                applyTheme(!isDark);
+                localStorage.setItem('theme', !isDark ? 'dark' : 'light');
+                window.dispatchEvent(new Event('themeChanged'));
+            });
+        }
+
+        // Sidebar Mobile Toggle
+        const sidebarBtn = document.getElementById('sidebarToggle');
+        const sidebar = document.getElementById('sidebar');
+        if(sidebarBtn) {
+            sidebarBtn.addEventListener('click', () => {
+                sidebar.classList.toggle('show');
+            });
+        }
+    });
+</script>`;
+
+fs.writeFileSync(path.join(partialsDir, 'scripts.ejs'), scriptsContent, 'utf8');
+
+console.log('Created layout partials successfully.');
+
+// 4. Update the files
+function getActiveNav(file) {
+    if (file.includes('dashboard')) return 'dashboard';
+    if (file.includes('analytics-dashboard') || file.includes('analytics')) return 'analytics';
+    if (file.includes('creator-crm')) return 'crm';
+    if (file.includes('dm-automation')) return 'dm-automation';
+    if (file.includes('settings')) return 'settings';
+    if (file.includes('my-links')) return 'my-links';
+    if (file.includes('suggestions')) return 'suggestions';
+    if (file.includes('vault')) return 'vault';
+    if (file.includes('home')) return 'home';
+    return '';
+}
+
+const filesToProcess = fs.readdirSync(viewsDir)
+    .filter(f => f.endsWith('.ejs') || f.endsWith('.html'))
+    .map(f => path.join(viewsDir, f));
+
+filesToProcess.forEach(file => {
+    let content = fs.readFileSync(file, 'utf8');
+    let original = content;
+
+    // Replace Sidebar
+    // Match either <aside class="sidebar"...>...</aside> or <!-- Sidebar --> ... </aside>
+    content = content.replace(/(?:<!-- Sidebar -->\s*)?<aside class="sidebar"[\s\S]*?<\/aside>/i, 
+        `<%- include('partials/layout/sidebar', { activeNav: '${getActiveNav(file)}' }) %>`);
+
+    // Replace Topbar
+    content = content.replace(/(?:<!-- Topbar -->\s*)?<header class="topbar"[\s\S]*?<\/header>/i, 
+        `<%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>`);
+
+    // Replace Scripts block if present (Theme Toggle & Sidebar Mobile Toggle)
+    // Some files have it wrapped in DOMContentLoaded, some don't.
+    // The easiest way is to match from "// Theme Toggle Logic" up to "// Sidebar Mobile Toggle" block
+    
+    // We can't safely strip it out via simple regex because of nested braces, so let's match the exact string chunks.
+    const scriptBlockRegex = /\s*\/\/\s*Theme Toggle Logic[\s\S]*?\/\/\s*Sidebar Mobile Toggle[\s\S]*?\}\);\s*\}\n/i;
+    content = content.replace(scriptBlockRegex, '');
+    
+    // In files like dashboard.ejs, after removing the script, we should inject the partial right before </body>
+    // Actually, better to inject `<%- include('partials/layout/scripts') %>` at the bottom of the body.
+    if (original.match(scriptBlockRegex) || original.includes('Theme Toggle Logic')) {
+        // If the file had it, add the partial before closing body if it's not already there
+        if (!content.includes('partials/layout/scripts')) {
+            content = content.replace(/<\/body>/i, `    <%- include('partials/layout/scripts') %>\n</body>`);
+        }
+    } else {
+         // Even if it didn't have it explicitly, it might need it if it uses the layout
+         if (content.includes('partials/layout/sidebar') && !content.includes('partials/layout/scripts')) {
+             content = content.replace(/<\/body>/i, `    <%- include('partials/layout/scripts') %>\n</body>`);
+         }
+    }
+
+    if (content !== original) {
+        fs.writeFileSync(file, content, 'utf8');
+        console.log(`Updated ${path.basename(file)}`);
+    }
+});

--- a/view/analytics-dashboard.ejs
+++ b/view/analytics-dashboard.ejs
@@ -1428,92 +1428,11 @@
 <body>
     <div class="dashboard-layout" id="dashboardLayout">
         
-        <!-- Sidebar -->
-        <aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
-            <a class="brand" href="/dashboard">
-                <span class="brand-mark">CO</span>
-                <div>
-                    <span class="brand-text">CreatorOS</span>
-                    <span class="brand-version">v2.0 Beta</span>
-                </div>
-            </a>
-            
-            
-
-            <!-- Workspace section -->
-            <nav class="sidebar-section">
-                <p class="sidebar-label">Workspace</p>
-                <a class="nav-link" href="/dashboard">
-                    <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
-                    <span class="nav-text">Dashboard</span>
-                </a>
-                <a class="nav-link" href="/services/url-shortener">
-                    <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
-                    <span class="nav-text">My Links</span>
-                </a>
-                <a class="nav-link active" href="/services/analytics-dashboard">
-                    <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
-                    <span class="nav-text">Analytics</span>
-                </a>
-                <a class="nav-link" href="/settings">
-                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
-                    <span class="nav-text">Settings</span>
-                </a>
-            </nav>
-
-            <!-- Services section -->
-            <nav class="sidebar-section" aria-label="Services">
-                <p class="sidebar-label">Services</p>
-                <% services.forEach((service) => { %>
-                    <a class="service-link <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
-                        <span class="service-name"><%= service.name %></span>
-                    </a>
-                <% }) %>
-            </nav>
-
-            <div class="sidebar-footer" style="margin-top: auto;">
-                <div class="upgrade-box">
-                    <h4>Upgrade Plan</h4>
-                    <p style="font-size: 0.9rem;">Get access to advanced webhooks & APIs.</p>
-                    <button class="upgrade-btn" type="button">Upgrade</button>
-                </div>
-                <a class="nav-link" href="/logout">
-                    <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
-                    <span class="nav-text">Logout</span>
-                </a>
-            </div>
-        </aside>
+        <%- include('partials/layout/sidebar', { activeNav: 'dashboard' }) %>
 
         <!-- Main Workspace Panel -->
         <main class="main">
-            <!-- Topbar -->
-            <header class="topbar">
-                <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
-                    <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
-                </button>
-
-                <div class="search-container">
-                    <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
-                    <input type="text" id="search-links-input" class="search-input" placeholder="Search shortened links..." />
-                </div>
-
-                <div class="topbar-actions">
-                    <button id="theme-toggle" class="action-icon-btn" type="button" aria-label="Toggle Theme">
-                <svg class="icon-light" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto;"><path d="M7.5 1.5V2.5M7.5 12.5V13.5M1.5 7.5H2.5M12.5 7.5H13.5M3.257 3.257L3.964 3.964M11.035 11.035L11.742 11.742M3.257 11.742L3.964 11.035M11.035 3.964L11.742 3.257" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/><circle cx="7.5" cy="7.5" r="2.75" stroke="currentColor" stroke-width="1.5"/></svg>
-                <svg class="icon-dark" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto; display:none;"><path d="M1.66 7.452C1.66 10.67 4.268 13.278 7.485 13.278C10.02 13.278 12.18 11.65 12.987 9.388C12.103 10.199 10.899 10.706 9.57 10.706C6.884 10.706 4.706 8.528 4.706 5.842C4.706 4.542 5.193 3.364 5.976 2.493C3.541 3.195 1.66 5.128 1.66 7.453Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-            </button>
-                    <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
-                    <a class="profile-chip" href="/profile">
-                        <span class="avatar"><%= user.initials %></span>
-                        <span class="profile-name"><%= user.name %></span>
-                    </a>
-                    <a class="primary-action-btn" href="/services/url-shortener">
-                        <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
-                        Create Link
-                    </a>
-                </div>
-            </header>
+            <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">
                 <!-- Dashboard Head -->
@@ -1738,5 +1657,6 @@
         });
 </script>
 
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/analytics.ejs
+++ b/view/analytics.ejs
@@ -526,75 +526,12 @@
 <body>
 <div class="layout">
 
-  <!-- SIDEBAR -->
-  <aside class="sidebar">
-    <div class="brand">
-      <h1>CreatorOS</h1>
-      <span class="beta">v2.0 Beta</span>
-    </div>
-
-    <nav>
-      <a href="/dashboard" class="nav-item">
-        <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-        Dashboard
-      </a>
-      <a href="/services/url-shortener" class="nav-item">
-        <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-        My Links
-      </a>
-      <a href="/services/analytics-dashboard" class="nav-item active">
-        <svg viewBox="0 0 24 24"><path d="M4 19V5"/><path d="M9 19V9"/><path d="M14 19V3"/><path d="M19 19v-7"/></svg>
-        Analytics
-      </a>
-      <a href="/services/creator-crm" class="nav-item">
-        <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-        CRM
-      </a>
-      <a href="/settings" class="nav-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-        Settings
-      </a>
-    </nav>
-
-    <div class="sidebar-spacer"></div>
-
-    <div class="upgrade-box">
-      <button>Upgrade Plan</button>
-    </div>
-
-    <a href="/support" class="nav-item">
-      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-      Support
-    </a>
-    <a href="/logout" class="nav-item">
-      <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
-      Log Out
-    </a>
-  </aside>
+  <%- include('partials/layout/sidebar', { activeNav: 'analytics' }) %>
 
   <!-- MAIN -->
   <div class="main">
 
-    <!-- TOPBAR -->
-    <header class="topbar">
-      <h2>Analytics</h2>
-      <div class="search-wrap">
-        <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-        <input class="search-input" type="text" placeholder="Search analytics data..." />
-      </div>
-      <div class="topbar-actions">
-        <button class="icon-btn">
-          <svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-        </button>
-        <button class="icon-btn">
-          <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-        </button>
-        <button class="icon-btn">
-          <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-        </button>
-        <button class="export-btn">Export Data</button>
-      </div>
-    </header>
+    <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
     <!-- CONTENT -->
     <section class="content">
@@ -833,5 +770,6 @@ makeMarker(20.59,  78.96,   9, '#b5882a', 'India',           '9%');
 L.control.zoom({ position: 'bottomright' }).addTo(map);
 </script>
 
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/bio-editor.ejs
+++ b/view/bio-editor.ejs
@@ -449,51 +449,12 @@
 <body>
 <div class="layout">
 
-  <!-- SIDEBAR -->
-  <aside class="sidebar">
-    <div class="brand">CreatorOS</div>
-
-    <a href="/dashboard" class="nav-item">
-      <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-      Dashboard
-    </a>
-    <a href="/vault" class="nav-item">
-      <svg viewBox="0 0 24 24"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>
-      Vault
-    </a>
-    <a href="/analytics" class="nav-item">
-      <svg viewBox="0 0 24 24"><path d="M4 19V5"/><path d="M9 19V9"/><path d="M14 19V3"/><path d="M19 19v-7"/></svg>
-      Analytics
-    </a>
-    <a href="/services/creator-crm" class="nav-item">
-      <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
-      CRM
-    </a>
-    <a href="/bio" class="nav-item active">
-      <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-      Smart Bio
-    </a>
-    <a href="/settings" class="nav-item">
-      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-      Settings
-    </a>
-  </aside>
+  <%- include('partials/layout/sidebar', { activeNav: '' }) %>
 
   <!-- MAIN -->
   <div class="main">
 
-    <!-- TOPBAR -->
-    <header class="topbar">
-      <h2>Smart Bio Editor</h2>
-      <div class="share-url">
-        <span>creatoros.com/<strong>@<%= user.handle || user.name.toLowerCase().replace(/\s+/g,'-') %></strong></span>
-        <button class="copy-btn" onclick="copyUrl()">Copy</button>
-      </div>
-      <div class="topbar-actions">
-        <a href="/bio/preview" target="_blank" class="btn-retro">Preview ↗</a>
-        <button class="btn-retro primary" onclick="saveBio()">Save Changes</button>
-      </div>
-    </header>
+    <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
     <!-- CONTENT -->
     <div class="content">
@@ -778,5 +739,6 @@
   // Init preview
   updatePreview();
 </script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/creator-crm.ejs
+++ b/view/creator-crm.ejs
@@ -625,59 +625,7 @@ body {
 <body>
 <div class="layout">
 
-  <!-- SIDEBAR -->
-  <aside class="sidebar">
-    <div class="brand">
-      <h1>CreatorOS</h1>
-      
-    </div>
-
-    <a href="/dashboard" class="nav-item">
-      <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-      Dashboard
-    </a>
-     <a class="nav-link" href="/vault">
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <polyline points="16 16 12 12 8 16"/>
-    <line x1="12" y1="12" x2="12" y2="21"/>
-    <path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/>
-  </svg>
-  <span class="nav-text">Vault</span>
-</a>
-     
-    <a href="/links" class="nav-item">
-      <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-      My Links
-    </a>
-    <a href="/analytics" class="nav-item">
-      <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-      Analytics
-    </a>
-    <a href="/services/creator-crm" class="nav-item active">
-      <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-      CRM
-    </a>
-    
-    <a href="/settings" class="nav-item">
-      <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-      Settings
-    </a>
-
-    <div class="sidebar-spacer"></div>
-
-    <button class="upgrade-btn">Upgrade Plan</button>
-
-    <div class="sidebar-footer">
-      <a href="/support" class="nav-item">
-        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-        Support
-      </a>
-      <a href="/logout" class="nav-item">
-        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
-        Log Out
-      </a>
-    </div>
-  </aside>
+  <%- include('partials/layout/sidebar', { activeNav: 'crm' }) %>
 
   <!-- MAIN -->
   <div class="main">
@@ -922,5 +870,6 @@ body {
   </div><!-- /main -->
 
 </div><!-- /layout -->
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/dashboard.ejs
+++ b/view/dashboard.ejs
@@ -1391,93 +1391,11 @@
 <body>
     <div class="dashboard-layout" id="dashboardLayout">
         
-        <!-- Sidebar -->
-        <aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
-            <a class="brand" href="/dashboard">
-                <span class="brand-mark">CO</span>
-                <div>
-                    <span class="brand-text">CreatorOS</span>
-                    <span class="brand-version">v2.0 Beta</span>
-                </div>
-            </a>
-            
-            
-
-            <!-- Workspace section -->
-            <nav class="sidebar-section">
-                <p class="sidebar-label">Workspace</p>
-                <a class="nav-link active" href="/dashboard">
-                    <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
-                    <span class="nav-text">Dashboard</span>
-                </a>
-                <a class="nav-link" href="/services/url-shortener">
-                    <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
-                    <span class="nav-text">My Links</span>
-                </a>
-                <a class="nav-link" href="/services/analytics-dashboard">
-                    <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
-                    <span class="nav-text">Analytics</span>
-                </a>
-               
-                <a class="nav-link" href="/settings">
-                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
-                    <span class="nav-text">Settings</span>
-                </a>
-            </nav>
-
-            <!-- Services section -->
-            <nav class="sidebar-section" aria-label="Services">
-                <p class="sidebar-label">Services</p>
-                <% services.forEach((service) => { %>
-                    <a class="service-link <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
-                        <span class="service-name"><%= service.name %></span>
-                    </a>
-                <% }) %>
-            </nav>
-
-            <div class="sidebar-footer" style="margin-top: auto;">
-                <div class="upgrade-box">
-                    <h4>Upgrade Plan</h4>
-                    <p style="font-size: 0.9rem;">Get access to advanced webhooks & APIs.</p>
-                    <button class="upgrade-btn" type="button">Upgrade</button>
-                </div>
-                <a class="nav-link" href="/logout">
-                    <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
-                    <span class="nav-text">Logout</span>
-                </a>
-            </div>
-        </aside>
+        <%- include('partials/layout/sidebar', { activeNav: 'dashboard' }) %>
 
         <!-- Main Workspace Panel -->
         <main class="main">
-            <!-- Topbar -->
-            <header class="topbar">
-                <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
-                    <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
-                </button>
-
-                <div class="search-container">
-                    <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
-                    <input type="text" id="search-links-input" class="search-input" placeholder="Search shortened links..." />
-                </div>
-
-                <div class="topbar-actions">
-                    <button id="theme-toggle" class="action-icon-btn" type="button" aria-label="Toggle Theme">
-                <svg class="icon-light" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto;"><path d="M7.5 1.5V2.5M7.5 12.5V13.5M1.5 7.5H2.5M12.5 7.5H13.5M3.257 3.257L3.964 3.964M11.035 11.035L11.742 11.742M3.257 11.742L3.964 11.035M11.035 3.964L11.742 3.257" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/><circle cx="7.5" cy="7.5" r="2.75" stroke="currentColor" stroke-width="1.5"/></svg>
-                <svg class="icon-dark" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto; display:none;"><path d="M1.66 7.452C1.66 10.67 4.268 13.278 7.485 13.278C10.02 13.278 12.18 11.65 12.987 9.388C12.103 10.199 10.899 10.706 9.57 10.706C6.884 10.706 4.706 8.528 4.706 5.842C4.706 4.542 5.193 3.364 5.976 2.493C3.541 3.195 1.66 5.128 1.66 7.453Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-            </button>
-                    <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
-                    <a class="profile-chip" href="/profile">
-                        <span class="avatar"><%= user.initials %></span>
-                        <span class="profile-name"><%= user.name %></span>
-                    </a>
-                    <a class="primary-action-btn" href="/services/url-shortener">
-                        <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
-                        Create Link
-                    </a>
-                </div>
-            </header>
+            <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">
                 <!-- Dashboard Head -->
@@ -1712,48 +1630,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            // Theme Toggle Logic
-            const themeBtn = document.getElementById('theme-toggle');
-        const root = document.documentElement;
-        const iconLight = themeBtn ? themeBtn.querySelector('.icon-light') : null;
-        const iconDark = themeBtn ? themeBtn.querySelector('.icon-dark') : null;
-        
-        function applyTheme(isDark) {
-            if (isDark) {
-                root.setAttribute('data-theme', 'dark');
-                if (iconLight) iconLight.style.display = 'none';
-                if (iconDark) iconDark.style.display = 'block';
-            } else {
-                root.removeAttribute('data-theme');
-                if (iconLight) iconLight.style.display = 'block';
-                if (iconDark) iconDark.style.display = 'none';
-            }
-        }
-
-        if (themeBtn) {
-            if (localStorage.getItem('theme') === 'dark') {
-                applyTheme(true);
-            } else {
-                applyTheme(false);
-            }
-
-            themeBtn.addEventListener('click', () => {
-                const isDark = root.getAttribute('data-theme') === 'dark';
-                applyTheme(!isDark);
-                localStorage.setItem('theme', !isDark ? 'dark' : 'light');
-                window.dispatchEvent(new Event('themeChanged'));
-            });
-        }
-
-            // Sidebar Mobile Toggle
-            const sidebarBtn = document.getElementById('sidebarToggle');
-            const sidebar = document.getElementById('sidebar');
-            if(sidebarBtn) {
-                sidebarBtn.addEventListener('click', () => {
-                    sidebar.classList.toggle('show');
-                });
-            }
-
             // Charts initialization with neo-brutalist styling
             const ctxClicks = document.getElementById('clicksChart');
             if (ctxClicks) {
@@ -1815,5 +1691,6 @@
             }
         });
     </script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/dm-automation.ejs
+++ b/view/dm-automation.ejs
@@ -1771,102 +1771,13 @@
   <div class="dashboard-layout" id="dashboardLayout">
 
     <!-- Left Sidebar Redesign -->
-    <aside class="sidebar" aria-label="Dashboard navigation">
-      <a class="brand" href="/dashboard">
-        <span class="brand-mark">CO</span>
-        <div>
-          <span class="brand-text">CreatorOS</span>
-          <span class="brand-version">v2.0 Beta</span>
-        </div>
-        <button id="theme-toggle" class="theme-btn" type="button" aria-label="Toggle Theme">☀️</button>
-      </a>
-
-      <!-- Workspace section -->
-      <nav class="sidebar-section">
-        <p class="sidebar-label">Workspace</p>
-        <a class="nav-link" href="/dashboard">
-          <svg class="nav-icon" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
-          <span class="nav-text">Dashboard</span>
-        </a>
-        <a class="nav-link" href="/dashboard#recent-links">
-          <svg class="nav-icon" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
-          <span class="nav-text">My Links</span>
-        </a>
-        <a class="nav-link" href="/dashboard#analytics">
-          <svg class="nav-icon" viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
-          <span class="nav-text">Analytics</span>
-        </a>
-        <a class="nav-link" href="/dashboard#settings">
-          <svg class="nav-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
-          <span class="nav-text">Settings</span>
-        </a>
-      </nav>
-
-      <!-- Services section -->
-      <nav class="sidebar-section" aria-label="Services">
-        <p class="sidebar-label">Services</p>
-        <% services.forEach(function(service) { %>
-          <a class="service-link <%= service.status %> <%= service.key === 'dm-automation' ? 'active' : '' %>"
-             href="<%= service.route %>" title="<%= service.name %>">
-            <svg class="nav-icon" viewBox="0 0 24 24"><%- service.svgPath || '<path d="M12 3v18M3 12h18"></path>' %></svg>
-            <span class="service-name"><%= service.name %></span>
-          </a>
-        <% }) %>
-      </nav>
-
-      <!-- Sidebar bottom footer -->
-      <div class="sidebar-footer">
-        <div class="upgrade-box">
-          <h4>Upgrade Plan</h4>
-          <p>Get access to advanced webhooks & Unlimited Auto-Replies.</p>
-          <button class="upgrade-btn" type="button">Upgrade Plan</button>
-        </div>
-        <a class="nav-link" href="#" style="margin-top:0.25rem;">
-          <svg class="nav-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01"></path></svg>
-          <span class="nav-text">Support</span>
-        </a>
-        <a class="nav-link" href="/logout">
-          <svg class="nav-icon" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
-          <span class="nav-text">Log Out</span>
-        </a>
-      </div>
-    </aside>
+    <%- include('partials/layout/sidebar', { activeNav: 'dm-automation' }) %>
 
     <!-- Main Panel -->
     <main class="main">
       
       <!-- Top Navigation -->
-      <header class="topbar">
-        <button class="menu-btn" type="button" id="sidebarToggle" aria-label="Toggle sidebar" aria-expanded="true">
-          <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
-        </button>
-        
-        <div class="search-container">
-          <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
-          <input type="text" id="search-automations-input" class="search-input" placeholder="Search automations..." aria-label="Search automations..." />
-        </div>
-
-        <div class="topbar-actions">
-          <div class="nav-actions-icons">
-            <button class="action-icon-btn" aria-label="Notifications" type="button">
-              <svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
-            </button>
-            <button class="action-icon-btn" aria-label="Help" type="button">
-              <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01"></path></svg>
-            </button>
-          </div>
-          
-          <a class="profile-chip" href="/profile">
-            <span class="avatar"><%= user.initials %></span>
-            <span class="profile-name"><%= user.name %></span>
-          </a>
-
-          <button class="btn-new-automation" type="button" onclick="openCreateView()">
-            <svg viewBox="0 0 24 24" style="width:1.1rem; height:1.1rem;"><path d="M12 5v14M5 12h14"></path></svg>
-            New Automation
-          </button>
-        </div>
-      </header>
+      <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
       <!-- Content wrapper scroll area -->
       <div class="content-scroll">
@@ -3145,5 +3056,6 @@
       updateDashboardUI();
     });
   </script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/home.ejs
+++ b/view/home.ejs
@@ -1420,92 +1420,11 @@
 <body>
     <div class="dashboard-layout" id="dashboardLayout">
         
-        <!-- Sidebar -->
-        <aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
-            <a class="brand" href="/dashboard">
-                <span class="brand-mark">CO</span>
-                <div>
-                    <span class="brand-text">CreatorOS</span>
-                    <span class="brand-version">v2.0 Beta</span>
-                </div>
-            </a>
-            
-            
-
-            <!-- Workspace section -->
-            <nav class="sidebar-section">
-                <p class="sidebar-label">Workspace</p>
-                <a class="nav-link" href="/dashboard">
-                    <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
-                    <span class="nav-text">Dashboard</span>
-                </a>
-                <a class="nav-link active" href="/services/url-shortener">
-                    <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
-                    <span class="nav-text">My Links</span>
-                </a>
-                <a class="nav-link" href="/services/analytics-dashboard">
-                    <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
-                    <span class="nav-text">Analytics</span>
-                </a>
-                <a class="nav-link" href="/settings">
-                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
-                    <span class="nav-text">Settings</span>
-                </a>
-            </nav>
-
-            <!-- Services section -->
-            <nav class="sidebar-section" aria-label="Services">
-                <p class="sidebar-label">Services</p>
-                <% services.forEach((service) => { %>
-                    <a class="service-link <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
-                        <span class="service-name"><%= service.name %></span>
-                    </a>
-                <% }) %>
-            </nav>
-
-            <div class="sidebar-footer" style="margin-top: auto;">
-                <div class="upgrade-box">
-                    <h4>Upgrade Plan</h4>
-                    <p style="font-size: 0.9rem;">Get access to advanced webhooks & APIs.</p>
-                    <button class="upgrade-btn" type="button">Upgrade</button>
-                </div>
-                <a class="nav-link" href="/logout">
-                    <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
-                    <span class="nav-text">Logout</span>
-                </a>
-            </div>
-        </aside>
+        <%- include('partials/layout/sidebar', { activeNav: 'home' }) %>
 
         <!-- Main Workspace Panel -->
         <main class="main">
-            <!-- Topbar -->
-            <header class="topbar">
-                <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
-                    <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
-                </button>
-
-                <div class="search-container">
-                    <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
-                    <input type="text" id="search-links-input" class="search-input" placeholder="Search shortened links..." />
-                </div>
-
-                <div class="topbar-actions">
-                    <button id="theme-toggle" class="action-icon-btn" type="button" aria-label="Toggle Theme">
-                <svg class="icon-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width:18px;height:18px;margin:auto;"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"></path></svg>
-                <svg class="icon-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width:18px;height:18px;margin:auto;display:none;"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-            </button>
-                    <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
-                    <a class="profile-chip" href="/profile">
-                        <span class="avatar"><%= locals.user ? locals.user.initials : "U" %></span>
-                        <span class="profile-name"><%= locals.user ? locals.user.name : "User" %></span>
-                    </a>
-                    <a class="primary-action-btn" href="/services/url-shortener">
-                        <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
-                        Create Link
-                    </a>
-                </div>
-            </header>
+            <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">
                 <div class="dashboard-head">
@@ -1795,5 +1714,6 @@
         "operatingSystem": "Web"
     }
     </script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/my-links.ejs
+++ b/view/my-links.ejs
@@ -1538,103 +1538,11 @@
 <body class="workspace-page links-page" data-user='<%- JSON.stringify({ name: user.name, initials: user.initials, isGuestContributor: isGuestContributor }) %>' data-domain="<%= domain %>">
     <div class="dashboard-layout" id="dashboardLayout">
         
-        <!-- Sidebar -->
-        <aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
-            <a class="brand" href="/dashboard">
-                <span class="brand-mark">CO</span>
-                <div>
-                    <span class="brand-text">CreatorOS</span>
-                    <span class="brand-version">v2.0 Beta</span>
-                </div>
-            </a>
-            
-            <button id="theme-toggle" class="theme-btn" type="button" aria-label="Toggle Theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width:18px;height:18px;margin:auto;"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"></path></svg>
-            </button>
-
-            <!-- Workspace section -->
-            <nav class="sidebar-section">
-                <p class="sidebar-label">Workspace</p>
-                <a class="nav-link" href="/dashboard">
-                    <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
-                    <span class="nav-text">Dashboard</span>
-                </a>
-                <a class="nav-link active" href="/services/url-shortener">
-                    <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
-                    <span class="nav-text">My Links</span>
-                </a>
-                <a class="nav-link" href="/services/analytics-dashboard">
-                    <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
-                    <span class="nav-text">Analytics</span>
-                </a>
-                <a class="nav-link" href="/settings">
-                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
-                    <span class="nav-text">Settings</span>
-                </a>
-            </nav>
-
-            <!-- Services section -->
-             
-            <nav class="sidebar-section" aria-label="Services">
-                <p class="sidebar-label">Services</p>
-
-<a class="service-link" href="/services/bio-builder">
-    <svg viewBox="0 0 24 24">
-        <path d="M12 3v18"></path>
-        <path d="M3 12h18"></path>
-    </svg>
-
-    <span class="service-name">
-        Smart Bio Builder
-    </span>
-</a>
-
-                <% services.forEach((service) => { %>
-                    <a class="service-link <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
-                        <span class="service-name"><%= service.name %></span>
-                    </a>
-                <% }) %>
-            </nav>
-
-            <div class="sidebar-footer" style="margin-top: auto;">
-                <div class="upgrade-box">
-                    <h4>Upgrade Plan</h4>
-                    <p style="font-size: 0.9rem;">Get access to advanced webhooks & APIs.</p>
-                    <button class="upgrade-btn" type="button">Upgrade</button>
-                </div>
-                <a class="nav-link" href="/logout">
-                    <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
-                    <span class="nav-text">Logout</span>
-                </a>
-            </div>
-        </aside>
+        <%- include('partials/layout/sidebar', { activeNav: 'my-links' }) %>
 
         <!-- Main Workspace Panel -->
         <main class="main">
-            <!-- Topbar -->
-            <header class="topbar">
-                <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
-                    <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
-                </button>
-
-                <div class="search-container">
-                    <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
-                    <input type="text" id="search-links-input" placeholder="Search shortened links..." />
-                </div>
-
-                <div class="topbar-actions">
-                    <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
-                    <a class="profile-chip" href="/profile">
-                        <span class="avatar"><%= user.initials %></span>
-                        <span class="profile-name"><%= user.name %></span>
-                    </a>
-                    <a class="primary-action-btn" href="/services/url-shortener">
-                        <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
-                        Create Link
-                    </a>
-                </div>
-            </header>
+            <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">
                 <!-- Dashboard Head -->
@@ -1797,6 +1705,7 @@
             searchInput.id = 'link-search'; // give it the ID expected by the JS
         }
     </script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>
 

--- a/view/partials/layout/scripts.ejs
+++ b/view/partials/layout/scripts.ejs
@@ -1,0 +1,45 @@
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // Theme Toggle Logic
+        const themeBtn = document.getElementById('theme-toggle');
+        const root = document.documentElement;
+        const iconLight = themeBtn ? themeBtn.querySelector('.icon-light') : null;
+        const iconDark = themeBtn ? themeBtn.querySelector('.icon-dark') : null;
+        
+        function applyTheme(isDark) {
+            if (isDark) {
+                root.setAttribute('data-theme', 'dark');
+                if (iconLight) iconLight.style.display = 'none';
+                if (iconDark) iconDark.style.display = 'block';
+            } else {
+                root.removeAttribute('data-theme');
+                if (iconLight) iconLight.style.display = 'block';
+                if (iconDark) iconDark.style.display = 'none';
+            }
+        }
+
+        if (themeBtn) {
+            if (localStorage.getItem('theme') === 'dark') {
+                applyTheme(true);
+            } else {
+                applyTheme(false);
+            }
+
+            themeBtn.addEventListener('click', () => {
+                const isDark = root.getAttribute('data-theme') === 'dark';
+                applyTheme(!isDark);
+                localStorage.setItem('theme', !isDark ? 'dark' : 'light');
+                window.dispatchEvent(new Event('themeChanged'));
+            });
+        }
+
+        // Sidebar Mobile Toggle
+        const sidebarBtn = document.getElementById('sidebarToggle');
+        const sidebar = document.getElementById('sidebar');
+        if(sidebarBtn) {
+            sidebarBtn.addEventListener('click', () => {
+                sidebar.classList.toggle('show');
+            });
+        }
+    });
+</script>

--- a/view/partials/layout/sidebar.ejs
+++ b/view/partials/layout/sidebar.ejs
@@ -1,0 +1,56 @@
+<aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
+    <a class="brand" href="/dashboard">
+        <span class="brand-mark">CO</span>
+        <div>
+            <span class="brand-text">CreatorOS</span>
+            <span class="brand-version">v2.0 Beta</span>
+        </div>
+    </a>
+
+    <!-- Workspace section -->
+    <nav class="sidebar-section">
+        <p class="sidebar-label">Workspace</p>
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'dashboard' ? 'active' : '' %>" href="/dashboard">
+            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
+            <span class="nav-text">Dashboard</span>
+        </a>
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'my-links' ? 'active' : '' %>" href="/services/url-shortener">
+            <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
+            <span class="nav-text">My Links</span>
+        </a>
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'analytics' ? 'active' : '' %>" href="/services/analytics-dashboard">
+            <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
+            <span class="nav-text">Analytics</span>
+        </a>
+       
+        <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'settings' ? 'active' : '' %>" href="/settings">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
+            <span class="nav-text">Settings</span>
+        </a>
+    </nav>
+
+    <!-- Services section -->
+    <nav class="sidebar-section" aria-label="Services">
+        <p class="sidebar-label">Services</p>
+        <% if (typeof services !== 'undefined' && services && services.length) { %>
+            <% services.forEach((service) => { %>
+                <a class="service-link <%= typeof activeNav !== 'undefined' && activeNav === service.route ? 'active' : '' %> <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
+                    <span class="service-name"><%= service.name %></span>
+                </a>
+            <% }) %>
+        <% } %>
+    </nav>
+
+    <div class="sidebar-footer" style="margin-top: auto;">
+        <div class="upgrade-box">
+            <h4>Upgrade Plan</h4>
+            <p style="font-size: 0.9rem;">Get access to advanced webhooks & APIs.</p>
+            <button class="upgrade-btn" type="button">Upgrade</button>
+        </div>
+        <a class="nav-link" href="/logout">
+            <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
+            <span class="nav-text">Logout</span>
+        </a>
+    </div>
+</aside>

--- a/view/partials/layout/topbar.ejs
+++ b/view/partials/layout/topbar.ejs
@@ -1,0 +1,26 @@
+<header class="topbar">
+    <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
+        <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
+    </button>
+
+    <div class="search-container">
+        <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+        <input type="text" id="search-links-input" class="search-input" placeholder="Search shortened links..." />
+    </div>
+
+    <div class="topbar-actions">
+        <button id="theme-toggle" class="action-icon-btn" type="button" aria-label="Toggle Theme">
+            <svg class="icon-light" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto;"><path d="M7.5 1.5V2.5M7.5 12.5V13.5M1.5 7.5H2.5M12.5 7.5H13.5M3.257 3.257L3.964 3.964M11.035 11.035L11.742 11.742M3.257 11.742L3.964 11.035M11.035 3.964L11.742 3.257" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/><circle cx="7.5" cy="7.5" r="2.75" stroke="currentColor" stroke-width="1.5"/></svg>
+            <svg class="icon-dark" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto; display:none;"><path d="M1.66 7.452C1.66 10.67 4.268 13.278 7.485 13.278C10.02 13.278 12.18 11.65 12.987 9.388C12.103 10.199 10.899 10.706 9.57 10.706C6.884 10.706 4.706 8.528 4.706 5.842C4.706 4.542 5.193 3.364 5.976 2.493C3.541 3.195 1.66 5.128 1.66 7.453Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
+        </button>
+        <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
+        <a class="profile-chip" href="/profile">
+            <span class="avatar"><%= typeof user !== 'undefined' ? user.initials : 'U' %></span>
+            <span class="profile-name"><%= typeof user !== 'undefined' ? user.name : 'User' %></span>
+        </a>
+        <a class="primary-action-btn" href="/services/url-shortener">
+            <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
+            Create Link
+        </a>
+    </div>
+</header>

--- a/view/suggestions.ejs
+++ b/view/suggestions.ejs
@@ -473,75 +473,11 @@
 <body>
   <div class="dashboard-layout" id="dashboardLayout">
 
-    <!-- Sidebar -->
-    <aside class="sidebar" aria-label="Dashboard navigation">
-      <a class="brand" href="/dashboard">
-        <span class="brand-mark">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
-            <path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11.2 4.73"></path>
-            <path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07l1.63-1.63"></path>
-          </svg>
-        </span>
-        <span>CREATOROS</span>
-      </a>
-
-      <nav class="sidebar-section">
-        <p class="sidebar-label">Workspace</p>
-        <a class="nav-link" href="/dashboard">
-          <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect>
-            <rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect>
-          </svg>
-          Dashboard
-        </a>
-        <a class="nav-link" href="/dashboard"><svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>My Links</a>
-        <a class="nav-link" href="/services/analytics-dashboard"><svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>Analytics</a>
-        <a class="nav-link" href="/settings"><svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>Settings</a>
-      </nav>
-
-      <nav class="sidebar-section" aria-label="Services">
-        <p class="sidebar-label">Services</p>
-        <% services.forEach((service) => { %>
-          <a class="service-link <%= service.status %> <%= service.key === 'suggestion-tool' ? 'active' : '' %>"
-             href="<%= service.route %>" title="<%= service.name %>">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><%- service.svgPath || '<path d="M12 3v18"></path><path d="M3 12h18"></path>' %></svg>
-            <span class="service-name"><%= service.name %></span>
-          </a>
-        <% }) %>
-      </nav>
-
-      <div class="sidebar-footer">
-        <a class="nav-link" href="/logout">
-          <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
-            <path d="m16 17 5-5-5-5"></path><path d="M21 12H9"></path>
-          </svg>
-          Logout
-        </a>
-      </div>
-    </aside>
+    <%- include('partials/layout/sidebar', { activeNav: 'suggestions' }) %>
 
     <!-- Main -->
     <main class="main">
-      <header class="topbar">
-        <button class="menu-btn" type="button" id="sidebarToggle" aria-label="Toggle sidebar" aria-expanded="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path>
-          </svg>
-        </button>
-        <div class="topbar-actions">
-          <a class="profile-chip" href="/profile">
-            <span class="avatar">CR</span>
-            <span class="profile-name">Creator</span>
-          </a>
-          <a class="icon-btn" href="/logout" aria-label="Logout">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
-              <path d="m16 17 5-5-5-5"></path><path d="M21 12H9"></path>
-            </svg>
-          </a>
-        </div>
-      </header>
+      <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
       <section class="content">
         <div class="page-head">
@@ -636,5 +572,6 @@
   </div>
 
   <script src="/js/pages/suggestions.js"></script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>

--- a/view/vault.ejs
+++ b/view/vault.ejs
@@ -510,71 +510,12 @@
 <body>
 <div class="layout">
 
-  <!-- SIDEBAR -->
-  <aside class="sidebar">
-    <div class="brand">CreatorOS</div>
-
-    <a href="/dashboard" class="nav-item">
-      <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-      Dashboard
-    </a>
-    <a href="/services/file-upload" class="nav-item active">
-      <svg viewBox="0 0 24 24"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-      Vault
-    </a>
-    <a href="/analytics" class="nav-item">
-      <svg viewBox="0 0 24 24"><path d="M4 19V5"/><path d="M9 19V9"/><path d="M14 19V3"/><path d="M19 19v-7"/></svg>
-      Analytics
-    </a>
-    <a href="/services/creator-crm" class="nav-item">
-      <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-      CRM
-    </a>
-    <a href="/settings" class="nav-item">
-      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-      Settings
-    </a>
-
-    <div class="sidebar-spacer"></div>
-
-    <div class="storage-box">
-      <div class="storage-label">Storage</div>
-      <div class="storage-bar-bg">
-        <div class="storage-bar" style="width: 75%;"></div>
-      </div>
-      <div class="storage-text">7.5GB / 10GB used</div>
-    </div>
-
-    <a href="/support" class="support-link">
-      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-      Support
-    </a>
-  </aside>
+  <%- include('partials/layout/sidebar', { activeNav: 'vault' }) %>
 
   <!-- MAIN -->
   <div class="main">
 
-    <!-- TOPBAR -->
-    <header class="topbar">
-      <div class="topbar-nav">
-        <span style="font-size:1.1rem; font-weight:800; margin-right:0.5rem;">CreatorOS</span>
-        <a href="#" class="topbar-nav-link active">Projects</a>
-        <a href="#" class="topbar-nav-link">Templates</a>
-      </div>
-      <div class="search-wrap">
-        <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-        <input class="search-input" type="text" id="searchInput" placeholder="Search Vault..." />
-      </div>
-      <div class="topbar-actions">
-        <button class="new-project-btn" onclick="showToast('New project created!')">New Project</button>
-        <button class="icon-btn">
-          <svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-        </button>
-        <button class="icon-btn">
-          <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-        </button>
-      </div>
-    </header>
+    <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
     <!-- CONTENT -->
     <section class="content">
@@ -754,5 +695,6 @@
     setTimeout(() => toast.classList.remove('show'), 2500);
   }
 </script>
+    <%- include('partials/layout/scripts') %>
 </body>
 </html>


### PR DESCRIPTION
This PR addresses the severe frontend structural duplication issue by abstracting the commonly copy-pasted UI components into reusable EJS partials. The massive sidebar, topbar, and theme/sidebar toggle JavaScript have been centralized into view/partials/layout/. All affected templates (dashboard.ejs, creator-crm.ejs, dm-automation.ejs, etc.) have been cleaned up and updated to cleanly <%- include %> these partials. The active navigation state is now passed dynamically via the activeNav local variable. This PR significantly reduces template bloat, removes over 760 lines of duplicated code, and ensures future UI updates only need to be made in one place.


Closes #199