### PR TITLE
Fix file vault redirect to new file upload page

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,13 +348,17 @@ app.get('/analytics', protect, asyncHandler(async (req, res) => {
     });
 }));
 
-// Vault
-app.get('/vault', protect, asyncHandler(async (req, res) => {
+// Vault redirect to new File Upload page
+app.get('/vault', protect, (req, res) => {
+    return res.redirect('/file-upload');
+});
+// File Upload page
+app.get('/file-upload', protect, asyncHandler(async (req, res) => {
     const userDoc = await User.findById(req.user.id)
         .select('name email')
         .lean();
 
-    return res.render('vault', {
+    return res.render('file-upload', {
         services,
         user: buildAccountViewModel(userDoc, req.user),
     });


### PR DESCRIPTION
## 📝 Description
This PR fixes the vault route by redirecting it to the new file upload page.

Previously, `/vault` directly rendered the vault view, which caused routing inconsistency after introducing the new file upload flow.

Now `/vault` properly redirects users to `/file-upload`, ensuring a cleaner and more consistent routing structure.

## 🔗 Related Issues
Fixes #171

## 🔄 Changes Made
- Updated `/vault` route to redirect to `/file-upload`
- Confirmed `/file-upload` route renders correctly with user data
- Ensured proper view rendering for authenticated users

## ✅ Testing
- Open `/vault` → it redirects to `/file-upload`
- File upload page loads without errors
- User information is displayed correctly

## 🚀 Notes
This is a non-breaking change and improves routing clarity and maintainability.
