### PR TITLE
fix: updated profile page with the theme of the site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -799,6 +799,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1268,7 +1269,8 @@
       "version": "0.0.1624250",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
       "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -1441,6 +1443,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/view/profile.ejs
+++ b/view/profile.ejs
@@ -15,17 +15,21 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
-            --bg: #06101f;
-            --bg-2: #0b1730;
-            --panel: rgba(13, 24, 49, 0.72);
-            --border: rgba(148, 163, 184, 0.18);
-            --text: #f8fafc;
-            --muted: #cbd5e1;
-            --accent-2: #38bdf8;
+            --bg: #f5f1ea;
+            --bg-2: #efe8dc;
+            --card-bg: #ffffff;
+            --text: #111111;
+            --muted: #4b5563;
+            --muted-2: #6b7280;
+            --border: #111111;
+            --accent-teal: #37d6c8;
+            --accent-blue: #76a9fa;
+            --accent-yellow: #e4c13b;
+            --success: #2bb673;
+            --shadow-retro: 3px 3px 0px var(--border);
         }
 
         * { box-sizing: border-box; }
@@ -33,26 +37,112 @@
         body {
             margin: 0;
             min-height: 100vh;
-            display: grid;
-            place-items: center;
-            padding: 2rem 1rem;
             font-family: 'Inter', sans-serif;
             color: var(--text);
             background:
-                radial-gradient(900px 320px at 50% -80px, rgba(56, 189, 248, 0.24), transparent 70%),
-                radial-gradient(720px 260px at 85% 0%, rgba(34, 211, 238, 0.18), transparent 70%),
-                linear-gradient(180deg, var(--bg-2), var(--bg));
+                linear-gradient(180deg, rgba(255,255,255,0.22), rgba(255,255,255,0.04)),
+                var(--bg);
+        }
+
+        .page-shell {
+            width: min(980px, calc(100% - 2rem));
+            margin: 0 auto;
+            padding: 2rem 0 2.5rem;
         }
 
         .profile-card {
-            width: min(520px, 100%);
-            padding: 2rem;
-            border: 1px solid var(--border);
-            border-radius: 1.5rem;
-            background: var(--panel);
-            backdrop-filter: blur(18px);
-            box-shadow: 0 24px 50px rgba(0, 0, 0, 0.28);
-            animation: enterUp 0.7s ease both;
+            background: var(--card-bg);
+            border: var(--border-thick, 2px solid var(--border));
+            box-shadow: var(--shadow-retro);
+            padding: 1.5rem;
+            display: grid;
+            gap: 1.25rem;
+        }
+
+        .page-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+            flex-wrap: wrap;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid var(--border);
+        }
+
+        .brand-block {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand-mark {
+            width: 2.4rem;
+            height: 2.4rem;
+            display: grid;
+            place-items: center;
+            background: var(--accent-teal);
+            border: 2px solid var(--border);
+            box-shadow: var(--shadow-retro);
+            font-weight: 700;
+            color: #111;
+            flex: 0 0 auto;
+        }
+
+        h1 {
+            margin: 0;
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: clamp(2rem, 5vw, 3rem);
+            line-height: 1;
+        }
+
+        .brand-copy {
+            display: grid;
+            gap: 0.15rem;
+        }
+
+        .brand-copy p {
+            margin: 0;
+            color: var(--muted-2);
+            font-size: 0.92rem;
+        }
+
+        .status-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 0.75rem;
+            border: 2px solid var(--border);
+            background: var(--accent-yellow);
+            box-shadow: var(--shadow-retro);
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 0.8rem;
+            font-weight: 700;
+        }
+
+        .hero {
+            display: grid;
+            grid-template-columns: 1.2fr 0.8fr;
+            gap: 1rem;
+            align-items: center;
+        }
+
+        .profile-main,
+        .profile-side {
+            border: 2px solid var(--border);
+            background: #fff;
+            box-shadow: var(--shadow-retro);
+            height: 100%;
+        }
+
+        .profile-main {
+            padding: 1.25rem;
+        }
+
+        .profile-side {
+            padding: 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .avatar {
@@ -60,10 +150,11 @@
             height: 4.2rem;
             display: grid;
             place-items: center;
-            border-radius: 1.4rem;
-            color: #082f49;
-            background: linear-gradient(135deg, #67e8f9, var(--accent-2));
-            box-shadow: 0 16px 32px rgba(34, 211, 238, 0.22);
+            border: 2px solid var(--border);
+            background: var(--accent-blue);
+            box-shadow: var(--shadow-retro);
+            color: #111;
+            flex: 0 0 auto;
         }
 
         .avatar svg {
@@ -71,89 +162,380 @@
             height: 2rem;
         }
 
-        h1 {
-            margin: 1.3rem 0 0.6rem;
-            font-size: clamp(2rem, 5vw, 2.8rem);
-            line-height: 1.1;
-            letter-spacing: 0;
+        .identity-block {
+            display: flex;
+            gap: 1rem;
+            align-items: flex-start;
         }
 
-        p {
-            margin: 0;
+        .profile-kicker {
+            margin: 0 0 0.35rem;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: var(--muted-2);
+        }
+
+        .handle {
+            margin: 0.35rem 0 0;
+            font-weight: 600;
             color: var(--muted);
-            line-height: 1.7;
         }
 
-        .profile-meta {
-            margin-top: 1.4rem;
-            padding: 1rem;
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            border-radius: 1rem;
-            background: rgba(255, 255, 255, 0.04);
+        .bio {
+            margin: 0.9rem 0 0;
             color: var(--muted);
-            overflow-wrap: anywhere;
+            line-height: 1.65;
+            max-width: 52ch;
         }
 
-        .actions {
+        .hero-actions {
             display: flex;
             flex-wrap: wrap;
             gap: 0.75rem;
-            margin-top: 1.5rem;
+            margin-top: 1.25rem;
         }
 
         .btn {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            border-radius: 999px;
-            padding: 0.85rem 1rem;
-            color: #042f3e;
-            background: linear-gradient(135deg, #67e8f9, var(--accent-2));
+            gap: 0.45rem;
+            padding: 0.8rem 1rem;
             text-decoration: none;
-            font-weight: 800;
-            transition: transform 0.2s ease, filter 0.2s ease;
+            font-weight: 700;
+            border: 2px solid var(--border);
+            box-shadow: var(--shadow-retro-btn, 2px 2px 0px var(--border));
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
         }
 
-        .btn.secondary {
+        .btn svg {
+            width: 0.95rem;
+            height: 0.95rem;
+        }
+
+        .btn-primary {
+            color: #111;
+            background: var(--accent-teal);
+        }
+
+        .btn-secondary {
             color: var(--text);
-            border: 1px solid rgba(255, 255, 255, 0.12);
-            background: rgba(255, 255, 255, 0.05);
+            background: var(--card-bg);
         }
 
         .btn:hover {
-            transform: translateY(-2px);
-            filter: brightness(1.03);
+            transform: translate(-1px, -1px);
         }
 
-        @keyframes enterUp {
-            from { opacity: 0; transform: translateY(24px); }
-            to { opacity: 1; transform: translateY(0); }
+        .info-grid {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 0.75rem;
+            width: 100%;
+        }
+
+        .info-box {
+            padding: 0.9rem;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            box-shadow: var(--shadow-retro-btn);
+        }
+
+        .info-label {
+            display: block;
+            margin-bottom: 0.3rem;
+            color: var(--muted-2);
+            font-size: 0.72rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        .info-value {
+            display: block;
+            color: var(--text);
+            font-size: 0.96rem;
+            font-weight: 600;
+            overflow-wrap: anywhere;
+        }
+
+        .section-title {
+            margin: 0 0 0.9rem;
+            padding-bottom: 0.6rem;
+            border-bottom: 2px solid var(--border);
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .list {
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .list-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.85rem 0.95rem;
+            border: 2px solid var(--border);
+            background: #fff;
+            box-shadow: var(--shadow-retro-btn);
+        }
+
+        .list-row strong {
+            color: var(--muted-2);
+            font-size: 0.72rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+
+        .list-row span {
+            text-align: right;
+            color: var(--text);
+            font-weight: 600;
+            overflow-wrap: anywhere;
+        }
+
+        .summary-card {
+            display: grid;
+            gap: 0.75rem;
+            padding: 1rem;
+            border: 2px solid var(--border);
+            background: var(--bg-secondary);
+            box-shadow: var(--shadow-retro-btn);
+        }
+
+        .summary-head {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: baseline;
+        }
+
+        .summary-head h2,
+        .panel h2 {
+            margin: 0;
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.2rem;
+            letter-spacing: -0.02em;
+        }
+
+        .summary-head p,
+        .panel p {
+            margin: 0;
+            color: var(--muted);
+            line-height: 1.7;
+        }
+
+        .bar {
+            height: 0.9rem;
+            margin-top: 0.25rem;
+            border: 2px solid var(--border);
+            background: #fff;
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .bar-fill {
+            width: 72%;
+            height: 100%;
+            border-radius: inherit;
+            background: var(--accent-blue);
+        }
+
+        .tag-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.55rem;
+        }
+
+        .tag {
+            padding: 0.45rem 0.75rem;
+            border: 2px solid var(--border);
+            background: var(--card-bg);
+            color: var(--text);
+            font-size: 0.84rem;
+            font-weight: 600;
+            box-shadow: var(--shadow-retro-btn);
+        }
+
+        .tag.good {
+            background: var(--accent-teal);
+        }
+
+        .tag.warn {
+            background: var(--accent-yellow);
+        }
+
+        .tag.neutral {
+            background: var(--card-bg);
+        }
+
+        .actions {
+            display: grid;
+            gap: 0.7rem;
+        }
+
+        .action-link {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: center;
+            padding: 0.95rem 1rem;
+            border: 2px solid var(--border);
+            color: var(--text);
+            text-decoration: none;
+            background: #fff;
+            box-shadow: var(--shadow-retro-btn);
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .action-link strong {
+            display: block;
+            margin-bottom: 0.15rem;
+        }
+
+        .action-link span {
+            color: var(--muted);
+            font-size: 0.92rem;
+            line-height: 1.4;
+        }
+
+        .action-link:hover {
+            transform: translate(-1px, -1px);
+        }
+
+        .action-link svg {
+            width: 1rem;
+            height: 1rem;
+            flex: 0 0 auto;
+            color: var(--text);
+        }
+
+        .footer-note {
+            margin: 0.25rem 0 0;
+            color: var(--muted);
+            font-size: 0.92rem;
+            line-height: 1.7;
+        }
+
+        @media (max-width: 900px) {
+            .hero {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        @media (max-width: 640px) {
+            .page-shell {
+                width: min(980px, calc(100% - 1rem));
+            }
+
+            .identity-block {
+                flex-direction: column;
+            }
+
+            .info-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .list-row,
+            .action-link {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .list-row span {
+                text-align: left;
+            }
         }
     </style>
 </head>
 <body>
-    <main class="profile-card">
-        <div class="avatar" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                <path d="M20 21a8 8 0 0 0-16 0"></path>
-                <circle cx="12" cy="7" r="4"></circle>
-            </svg>
-        </div>
+    <div class="page-shell">
+        <main class="profile-card">
+            <header class="page-header">
+                <div class="brand-block">
+                    <div class="brand-mark">CO</div>
+                    <div class="brand-copy">
+                        <h1>Profile</h1>
+                    </div>
+                </div>
+            </header>
 
-        <h1><%= user.name %></h1>
-        <p>Your CreatorOS account is active. More profile details can be added here as the account system grows.</p>
+            <% const rawHandle = user.alias ? String(user.alias).replace(/^@+/, '') : ''; %>
+            <% const displayHandle = rawHandle ? '@' + rawHandle : '@creator'; %>
+            <% const bioText = user.bio && user.bio.trim() ? user.bio : 'Your profile details live here in a clean, lightweight summary.'; %>
 
-        <div class="profile-meta">
-            <% if (user.email) { %>
-                Email: <%= user.email %><br>
-            <% } %>
-            User ID: <%= user && user.id ? user.id : 'Authenticated user' %>
-        </div>
+            <section class="hero">
+                <div class="profile-main">
+                    <div class="identity-block">
+                        <div class="avatar" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M20 21a8 8 0 0 0-16 0"></path>
+                                <circle cx="12" cy="7" r="4"></circle>
+                            </svg>
+                        </div>
 
-        <div class="actions">
-            <a class="btn" href="/dashboard">Back to dashboard</a>
-            <a class="btn secondary" href="/logout">Logout</a>
-        </div>
-    </main>
+                        <div>
+                            <p class="profile-kicker">Workspace identity</p>
+                            <h1><%= user.name %></h1>
+                            <p class="handle"><%= displayHandle %></p>
+                            <p class="bio"><%= bioText %></p>
+
+                            <div class="hero-actions">
+                                <a class="btn btn-primary" href="/settings">Edit profile</a>
+                                <a class="btn btn-secondary" href="/dashboard">Back to dashboard</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <aside class="profile-side">
+                    <div class="info-grid">
+                        <div class="info-box">
+                            <span class="info-label">Email</span>
+                            <span class="info-value"><%= user.email || 'Not connected' %></span>
+                        </div>
+                        <div class="info-box">
+                            <span class="info-label">User ID</span>
+                            <span class="info-value"><%= user.id || 'Authenticated session' %></span>
+                        </div>
+                    </div>
+                </aside>
+            </section>
+
+            <section class="panel summary-card">
+                <div class="summary-head">
+                    <h2>Quick actions</h2>
+                </div>
+                <div class="actions">
+                    <a class="action-link" href="/settings">
+                        <div>
+                            <strong>Open settings</strong>
+                            <span>Update profile, security, and preferences.</span>
+                        </div>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path d="m9 18 6-6-6-6"></path>
+                        </svg>
+                    </a>
+                    <a class="action-link" href="/logout">
+                        <div>
+                            <strong>Logout</strong>
+                            <span>End the current CreatorOS session.</span>
+                        </div>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path d="m9 18 6-6-6-6"></path>
+                        </svg>
+                    </a>
+                </div>
+            </section>
+        </main>
+    </div>
 </body>
 </html>


### PR DESCRIPTION

## 📝 Description
Refines the profile page to match the CreatorOS neo-brutalist dashboard theme and simplifies the layout for a cleaner user-facing account overview.

## 🔗 Related Issues
Fixes #178

## 📋 Type of Change
- [x] 🎨 Style changes
- [x] ♻️ Code refactoring

## 🔄 Changes Made
- Simplified the profile page into a cleaner, lighter layout that matches the rest of the site.
- Removed extra profile metadata sections to keep the page minimal for users.
- Fixed handle rendering so `@` is only shown once.
- Centered the email and user ID block and balanced the profile panel layout.

## ✅ Testing

### How to Test
1. Open `/profile` in the browser.
2. Confirm the page uses the same retro dashboard styling as the rest of CreatorOS.
3. Confirm the handle renders correctly and the email/user ID block is centered and stacked cleanly.

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots 
<img width="1280" height="758" alt="Screenshot 2026-06-16 at 23 07 35" src="https://github.com/user-attachments/assets/1ff6883b-9636-4fb4-8747-e114473257d7" />


## 🚀 Deployment Notes
No special deployment steps required.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My PR title follows the naming convention
- [ ] I have linked related issues

## 📝 Additional Context
This change focuses only on presentation and layout for the profile page. The settings page remains the place for detailed account editing.

---

