### PR TITLE
Fix/mock invite create

### DIFF
--- a/model/invite.js
+++ b/model/invite.js
@@ -76,6 +76,9 @@ const MockInviteModel = {
       updatedAt: new Date(),
     };
   },
+  deleteMany: async () => {
+    return { deletedCount: 0 };
+  },
 };
 
 function getActiveInviteModel() {
@@ -90,6 +93,7 @@ const InviteModel = {
   findByIdAndDelete: (...args) => getActiveInviteModel().findByIdAndDelete(...args),
   find: (...args) => getActiveInviteModel().find(...args),
   create: (...args) => getActiveInviteModel().create(...args),
+  deleteMany: (...args) => getActiveInviteModel().deleteMany(...args),
 };
 
 module.exports = InviteModel;

--- a/model/invite.js
+++ b/model/invite.js
@@ -67,6 +67,15 @@ const MockInviteModel = {
   findOne: async () => null,
   findByIdAndDelete: async () => null,
   find: () => emptyInviteQuery,
+  create: async (data) => {
+    return {
+      _id: new mongoose.Types.ObjectId().toString(),
+      ...data,
+      status: 'pending',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  },
 };
 
 function getActiveInviteModel() {

--- a/model/url.js
+++ b/model/url.js
@@ -127,6 +127,19 @@ class MockUrlModel {
         if (idx === -1) return null;
         return mockUrls.splice(idx, 1)[0];
     }
+
+    static async deleteMany(query = {}) {
+        const keys = Object.keys(query);
+        let count = 0;
+        for (let i = mockUrls.length - 1; i >= 0; i--) {
+            const item = mockUrls[i];
+            if (keys.every(k => item[k]?.toString() === query[k]?.toString())) {
+                mockUrls.splice(i, 1);
+                count++;
+            }
+        }
+        return { deletedCount: count };
+    }
 }
 
 function getActiveUrlModel() {
@@ -146,5 +159,6 @@ UrlModel.findById = (...args) => getActiveUrlModel().findById(...args);
 UrlModel.findOneAndUpdate = (...args) => getActiveUrlModel().findOneAndUpdate(...args);
 UrlModel.find = (...args) => getActiveUrlModel().find(...args);
 UrlModel.findByIdAndDelete = (...args) => getActiveUrlModel().findByIdAndDelete(...args);
+UrlModel.deleteMany = (...args) => getActiveUrlModel().deleteMany(...args);
 
 module.exports = UrlModel;

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -211,6 +211,20 @@ router.delete('/account', preventContributorWrites, asyncHandler(async (req, res
     const user = await User.findById(req.user.id);
     if (!user) return res.status(404).json({ error: 'User not found' });
     
+    // Import other models for cascading deletion
+    const Url = require('../model/url');
+    const Invite = require('../model/invite');
+
+    // Delete shortened links and collaborator invites associated with the user
+    await Url.deleteMany({ userId: user._id });
+    await Invite.deleteMany({ inviter: user._id });
+
+    // Only attempt to delete Creator settings if not in mock database mode (Creator model is not mocked)
+    if (process.env.USE_MOCK_DB !== 'true') {
+        const Creator = require('../model/creator');
+        await Creator.deleteOne({ userId: user._id });
+    }
+
     if (typeof user.deleteOne === 'function') {
         await user.deleteOne();
     }


### PR DESCRIPTION
## 📝 Description
This PR implements cascading data deletion when a user deletes their account to ensure proper data hygiene and GDPR compliance (the Right to Erasure / Right to be Forgotten). Previously, deleting an account left orphaned records (shortened links, collaborator invitations, and creator settings) in the database. 

This fix ensures all associated user data is securely deleted and includes safeguards to maintain compatibility under the local mock database mode.

## 🔗 Related Issues
Fixes #237 

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- **`routes/settings.js`**: Updated the `DELETE /api/settings/account` handler to clean up all shortened links (`Url`) and collaborator invites (`Invite`) associated with the user. Safely skips `Creator` collection deletion when running in local mock database mode (as `Creator` settings are not mocked) to avoid unmocked Mongoose query crashes.
- **`model/url.js`**: Implemented the static `deleteMany` helper in the in-memory `MockUrlModel` database to support cascading deletion and prevent crash exceptions during local mock database runs.
- **`model/invite.js`**: Implemented a mock static `deleteMany` wrapper in `MockInviteModel` to maintain database layer compatibility in mock configuration.

## ✅ Testing

### How to Test
1. Set the application to mock database mode: `USE_MOCK_DB=true`.
2. Run the development server using:
   ```bash
   cmd.exe /c "npm run dev"
