### PR TITLE
fix(security): Apply granular rate limiters to vulnerable authentication and email endpoints

### DIFF
--- a/middleware/rateLimiters.js
+++ b/middleware/rateLimiters.js
@@ -44,9 +44,35 @@ const urlShortenerApiLimiter = rateLimit({
     }
 });
 
+const signupLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    handler: (req, res) => {
+        const message = 'Too many accounts created from this IP, please try again later.';
+        if (wantsHtml(req)) {
+            return res.status(429).render('signup', { error: message });
+        }
+        return res.status(429).json({ success: false, message, error: message });
+    }
+});
+
+const emailVerificationLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 5,
+    handler: (req, res) => {
+        const message = 'Too many requests. Please wait before trying again.';
+        if (wantsHtml(req)) {
+            return res.status(429).render('resend-verification', { error: message, success: null });
+        }
+        return res.status(429).json({ success: false, message, error: message });
+    }
+});
+
 module.exports = {
     loginLimiter,
     uploadLimiter,
     urlShortenerPageLimiter,
-    urlShortenerApiLimiter
+    urlShortenerApiLimiter,
+    signupLimiter,
+    emailVerificationLimiter
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,6 +4,7 @@ const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const { signup, login, handleGoogleCallback, loginAsContributor, verifyEmail, resendVerificationEmail } = require("../controller/auth");
 const { signupValidator, loginValidator, resendVerificationValidator } = require("../middleware/validators");
 const connectDB = require("../connect");
+const { signupLimiter, emailVerificationLimiter } = require("../middleware/rateLimiters");
 
 const router = express.Router();
 
@@ -135,7 +136,7 @@ router.get("/login", (req, res) => {
  *       500:
  *         description: Internal server error
  */
-router.post("/signup", signupValidator, signup);
+router.post("/signup", signupLimiter, signupValidator, signup);
 
 /**
  * @swagger
@@ -287,7 +288,7 @@ router.get("/verify-email", (req, res) => {
  *       500:
  *         description: Internal server error
  */
-router.post("/verify-email", verifyEmail);
+router.post("/verify-email", emailVerificationLimiter, verifyEmail);
 
 
 /**
@@ -327,7 +328,7 @@ router.get("/resend-verification", (req, res) => {
  *       500:
  *         description: Internal server error
  */
-router.post("/resend-verification", resendVerificationValidator, resendVerificationEmail);
+router.post("/resend-verification", emailVerificationLimiter, resendVerificationValidator, resendVerificationEmail);
 
 
 /**


### PR DESCRIPTION
This Pull Request resolves a critical security vulnerability where automated bots could abuse authentication and email endpoints to spam the database or exhaust external email service quotas. It expands middleware/rateLimiters.js by defining two new granular express-rate-limit instances: signupLimiter (which restricts the number of accounts created per IP within a specific timeframe) and emailVerificationLimiter (which throttles repeated verification email dispatches). These new middlewares have been strategically injected into routes/auth.js for the /signup, /verify-email, and /resend-verification POST routes. By modularizing these rate limiters entirely within the middleware and route declaration layers, the core business logic remains untouched, guaranteeing zero merge conflicts with concurrent feature development across other branches.

Closes #255 