### PR TITLE
Fix: Add HMAC verification to Instagram Webhook

### DIFF
--- a/controller/instagramWebhookController.js
+++ b/controller/instagramWebhookController.js
@@ -1,6 +1,8 @@
 const { dmQueue } = require('../services/dmQueueService');
 const asyncHandler = require('../utils/asyncHandler');
 
+const crypto = require('crypto');
+
 // Verify the webhook from Meta
 const verifyWebhook = (req, res) => {
     // You should store your Verify Token in an environment variable
@@ -20,6 +22,42 @@ const verifyWebhook = (req, res) => {
     }
     
     return res.status(400).send('Missing hub variables');
+};
+
+const verifyWebhookSignature = (req, res, next) => {
+    const signature = req.headers['x-hub-signature-256'];
+    
+    if (!signature) {
+        console.warn('[Webhook] Missing X-Hub-Signature-256 header');
+        return res.sendStatus(403);
+    }
+    
+    const APP_SECRET = process.env.INSTAGRAM_APP_SECRET;
+    
+    if (!APP_SECRET) {
+        console.error('[Webhook] INSTAGRAM_APP_SECRET is not configured');
+        return res.sendStatus(500);
+    }
+    
+    const payload = req.rawBody;
+    
+    if (!payload) {
+        console.error('[Webhook] Raw body is missing. Ensure express.json({verify: ...}) is configured.');
+        return res.sendStatus(500);
+    }
+
+    const expectedSignature = 'sha256=' + crypto.createHmac('sha256', APP_SECRET).update(payload).digest('hex');
+
+    try {
+        if (crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+            return next();
+        }
+    } catch (e) {
+        // catch error if buffer lengths don't match
+    }
+
+    console.warn('[Webhook] Invalid signature');
+    return res.sendStatus(403);
 };
 
 // Handle incoming webhook events
@@ -72,5 +110,6 @@ const handleWebhook = asyncHandler(async (req, res, next) => {
 
 module.exports = {
     verifyWebhook,
+    verifyWebhookSignature,
     handleWebhook
 };

--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ const { generateCsrf, verifyCsrf } = require('./middleware/csrf');
 
 app.use(cookieParser());
 app.use(express.urlencoded({ extended: true }));
-app.use(express.json());
+app.use(express.json({
+    verify: (req, res, buf) => {
+        req.rawBody = buf;
+    }
+}));
 app.use(generateCsrf);
 app.use(verifyCsrf);
 app.use(passport.initialize());

--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { getInstagramProfile } = require('../controller/instagramController');
-const { verifyWebhook, handleWebhook } = require('../controller/instagramWebhookController');
+const { verifyWebhook, verifyWebhookSignature, handleWebhook } = require('../controller/instagramWebhookController');
 
 const router = express.Router();
 
@@ -25,6 +25,6 @@ router.get('/profile', getInstagramProfile);
 
 // Instagram DM Automation Webhook Endpoints
 router.get('/webhook', verifyWebhook);
-router.post('/webhook', handleWebhook);
+router.post('/webhook', verifyWebhookSignature, handleWebhook);
 
 module.exports = router;


### PR DESCRIPTION
This PR addresses a critical security vulnerability by implementing strict HMAC signature verification for all incoming Instagram Webhook events, ensuring that only legitimate payloads originating from Meta are processed. I configured express.json() in index.js with a verify function to reliably capture the raw buffer of the incoming request body, which is required for accurate cryptographic hashing. I then introduced a new verifyWebhookSignature middleware in instagramWebhookController.js that hashes this raw payload using the INSTAGRAM_APP_SECRET and utilizes Node.js crypto.timingSafeEqual() to mitigate timing attacks when comparing it against the X-Hub-Signature-256 header. This middleware has been applied to the POST /webhook route, safely dropping any forged or malicious requests with a 403 Forbidden status before they can reach the DM queue.

Closes #257 