### PR TITLE
Fixed a bug where expired invitations could still be accepted in  `acceptInviteFromDashboard`.

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -177,6 +177,14 @@ const acceptInviteFromDashboard = asyncHandler(async (req, res, next) => {
     if (!invite) {
       return renderDashboard(req, res, { inviteAcceptError: 'No invitation found for that token.' });
     }
+   if (
+       invite.status === "expired" ||
+       (invite.expiresAt && invite.expiresAt < new Date())
+   ) {
+       return renderDashboard(req, res, {
+           inviteAcceptError: "This invitation has expired.",
+       })
+   };
 
     if (invite.status === 'accepted') {
       return renderDashboard(req, res, { inviteAcceptMessage: 'This invitation has already been accepted.' });


### PR DESCRIPTION

## Problem

The function never checked whether an invite was expired before 
accepting it. The system already has an `expired` status used on 
the dashboard summary, but it was never actually enforced when a 
user tried to accept an invite. This meant an old invite link from 
months ago could still be accepted today.


## What changed

Added a check right after verifying the invite exists, and before 
checking if it was already accepted. If the invite's status is 
`expired`, or its `expiresAt` date has already passed, the user 
now sees a clear error message and the invite is not accepted.



## Before

```js
const invite = await Invite.findOne({ token: inviteToken.trim() });

if (!invite) {
  return renderDashboard(req, res, { inviteAcceptError: 'No invitation found for that token.' });
}

if (invite.status === 'accepted') {
  return renderDashboard(req, res, { inviteAcceptMessage: 'This invitation has already been accepted.' });
}

invite.status = 'accepted';
invite.acceptedAt = new Date();
await invite.save();
```


## After

```js
const invite = await Invite.findOne({ token: inviteToken.trim() });

if (!invite) {
  return renderDashboard(req, res, { inviteAcceptError: 'No invitation found for that token.' });
}

if (
  invite.status === "expired" ||
  (invite.expiresAt && invite.expiresAt < new Date())
) {
  return renderDashboard(req, res, {
    inviteAcceptError: "This invitation has expired.",
  });
}

if (invite.status === 'accepted') {
  return renderDashboard(req, res, { inviteAcceptMessage: 'This invitation has already been accepted.' });
}

invite.status = 'accepted';
invite.acceptedAt = new Date();
await invite.save();
```

---

## Why it matters

- Invites are meant to be time-bound — accepting a stale invite 
  defeats that purpose
- A leaked or forgotten invite link no longer remains valid forever
- The `expired` status now has actual enforcement, matching what 
  the dashboard UI already implies

## Testing

- Tried accepting an invite with `status: 'expired'` → correctly 
  blocked with error message
- Tried accepting an invite with `expiresAt` in the past → correctly 
  blocked with error message
- Tried accepting a valid, non-expired invite → works as before


## Files changed

- `collaborationController.js`


Closes #241