### PR TITLE
fix: replace analytics mocks with real Instagram API fetch

### DIFF
--- a/controller/analytics.js
+++ b/controller/analytics.js
@@ -43,21 +43,32 @@ const triggerRefresh = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Creator not found" });
     }
 
-    // TODO: Replace with real API fetch
-    const mockData = {
-        followers: Math.floor(Math.random() * 10000),
-        following: Math.floor(Math.random() * 1000),
-        totalPosts: Math.floor(Math.random() * 500),
-        totalLikes: Math.floor(Math.random() * 50000),
-        totalComments: Math.floor(Math.random() * 5000),
-        totalViews: Math.floor(Math.random() * 100000),
-        engagementRate: parseFloat((Math.random() * 10).toFixed(2)),
+    let fetchedData = {
+        followers: 0,
+        following: 0,
+        totalPosts: 0,
+        totalLikes: 0,
+        totalComments: 0,
+        totalViews: 0,
+        engagementRate: 0,
     };
+
+    if (creator.platform === 'instagram') {
+        try {
+            const { fetchInstagramProfile } = require('../utils/instagramProfileService');
+            const profile = await fetchInstagramProfile(creator.username);
+            fetchedData.followers = profile.followers || 0;
+            fetchedData.following = profile.following || 0;
+            fetchedData.totalPosts = profile.totalPosts || 0;
+        } catch (err) {
+            console.error(`[Analytics] Failed to fetch profile for ${creator.username}:`, err.message);
+        }
+    }
 
     const snapshot = await AnalyticsSnapshot.create({
         creatorId: creator._id,
         platform: creator.platform,
-        ...mockData,
+        ...fetchedData,
         snapshotDate: new Date(),
     });
 

--- a/workers/analyticsRefreshWorker.js
+++ b/workers/analyticsRefreshWorker.js
@@ -11,16 +11,27 @@ cron.schedule("0 */6 * * *", async () => {
         const creators = await Creator.find({});
 
         for (const creator of creators) {
-            // TODO: Replace with real platform API call (e.g. Instagram Graph API)
-            const mockFetchedData = {
-                followers: Math.floor(Math.random() * 10000),
-                following: Math.floor(Math.random() * 1000),
-                totalPosts: Math.floor(Math.random() * 500),
-                totalLikes: Math.floor(Math.random() * 50000),
-                totalComments: Math.floor(Math.random() * 5000),
-                totalViews: Math.floor(Math.random() * 100000),
-                engagementRate: parseFloat((Math.random() * 10).toFixed(2)),
+            let fetchedData = {
+                followers: 0,
+                following: 0,
+                totalPosts: 0,
+                totalLikes: 0,
+                totalComments: 0,
+                totalViews: 0,
+                engagementRate: 0,
             };
+
+            if (creator.platform === 'instagram') {
+                try {
+                    const { fetchInstagramProfile } = require('../utils/instagramProfileService');
+                    const profile = await fetchInstagramProfile(creator.username);
+                    fetchedData.followers = profile.followers || 0;
+                    fetchedData.following = profile.following || 0;
+                    fetchedData.totalPosts = profile.totalPosts || 0;
+                } catch (err) {
+                    console.error(`[AnalyticsWorker] Failed to fetch profile for ${creator.username}:`, err.message);
+                }
+            }
 
             // Get last snapshot for growth comparison
             const lastSnapshot = await AnalyticsSnapshot.findOne(
@@ -33,7 +44,7 @@ cron.schedule("0 */6 * * *", async () => {
             const newSnapshot = await AnalyticsSnapshot.create({
                 creatorId: creator._id,
                 platform: creator.platform,
-                ...mockFetchedData,
+                ...fetchedData,
                 snapshotDate: new Date(),
             });
 
@@ -42,10 +53,10 @@ cron.schedule("0 */6 * * *", async () => {
                 await EngagementHistory.create({
                     creatorId: creator._id,
                     snapshotId: newSnapshot._id,
-                    followersGrowth: mockFetchedData.followers - lastSnapshot.followers,
-                    likesGrowth: mockFetchedData.totalLikes - lastSnapshot.totalLikes,
-                    commentsGrowth: mockFetchedData.totalComments - lastSnapshot.totalComments,
-                    engagementRateDelta: mockFetchedData.engagementRate - lastSnapshot.engagementRate,
+                    followersGrowth: fetchedData.followers - lastSnapshot.followers,
+                    likesGrowth: fetchedData.totalLikes - lastSnapshot.totalLikes,
+                    commentsGrowth: fetchedData.totalComments - lastSnapshot.totalComments,
+                    engagementRateDelta: fetchedData.engagementRate - lastSnapshot.engagementRate,
                 });
             }
 


### PR DESCRIPTION
This pull request resolves the issue where analytics data was still being randomly generated using Math.random(). It refactors controller/analytics.js and workers/analyticsRefreshWorker.js by completely stripping out the dummy data implementations. Instead, it now imports the fetchInstagramProfile utility and fetches real follower, following, and post count metrics for the creator's username (if their platform is set to instagram).

Closes #277 