### PR TITLE
fix: resolve shortId collision vulnerability with retry loop

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -79,9 +79,18 @@ async function handleGenerateShortUrl(req, res) {
         }
         shortId = slug;
     } else {
-        const existing = await Url.findOne({ shortId });
-        if (existing) {
+        let retries = 0;
+        const MAX_RETRIES = 5;
+        let existing = await Url.findOne({ shortId });
+        
+        while (existing && retries < MAX_RETRIES) {
             shortId = shortid();
+            existing = await Url.findOne({ shortId });
+            retries++;
+        }
+        
+        if (existing) {
+            return res.status(500).json({ error: 'Failed to generate a unique short URL. Please try again later.' });
         }
     }
 


### PR DESCRIPTION
This pull request resolves a critical edge case in the handleGenerateShortUrl controller (controller/url.js) where generating a duplicate shortId could cause an unhandled database exception. I have removed the fragile, single-check if (existing) logic and replaced it with a while loop that will retry generating a random short ID up to 5 times if collisions occur. If it fails after 5 retries, it now fails gracefully with a standard HTTP 500 error response instead of crashing the server.

Closes #281 