### PR TITLE
fix: remove auth bypass and enforce bcrypt password check

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -221,22 +221,21 @@ const login = asyncHandler(async (req, res, next) => {
     const { email, password } = req.body || {};
     const normalizedEmail = (email && typeof email === 'string') ? email.toLowerCase().trim() : "";
     
-    // Allow login with any credentials: find user by email, or get the first user, or create a mock user
-    let user = null;
-    if (normalizedEmail) {
-        user = await User.findOne({ email: normalizedEmail });
+    if (!normalizedEmail || !password) {
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
+
+    const user = await User.findOne({ email: normalizedEmail });
     if (!user) {
-        user = await User.findOne({});
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
-    if (!user) {
-        user = await User.create({
-            name: "Test User",
-            email: normalizedEmail || "test@local.com",
-            password: await bcrypt.hash("Password123!", 10),
-            role: "creator",
-            isVerified: true
-        });
+
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+        if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
+        return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
 
     user.isVerified = true;


### PR DESCRIPTION
This pull request resolves a critical security vulnerability within controller/auth.js where malicious actors could completely bypass the login screen. I have entirely removed the unsafe User.findOne({}) fallback and the dummy "Test User" creation block. In its place, I implemented robust email validation and a strict bcrypt.compare(password, user.password) check. Now, any failed login attempts cleanly return a 401 Unauthorized generic response without leaking user information or inappropriately granting dashboard access.

Closes #290 