### PR TITLE
fix: remove hardcoded Math.random rate limit simulation from DM worker

### DIFF
--- a/services/dmQueueService.js
+++ b/services/dmQueueService.js
@@ -83,12 +83,6 @@ async function sendInstagramDM(recipientId, text) {
     // e.g. await axios.post(`https://graph.facebook.com/v19.0/me/messages`, ...)
     console.log(`[Instagram API] Sending DM to ${recipientId}: "${text}"`);
     
-    // Simulate rate-limiting randomly for testing the queue logic
-    if (Math.random() < 0.2) {
-        const error = new Error('Instagram API Rate Limit Exceeded');
-        error.code = 429;
-        throw error;
-    }
     
     return true;
 }


### PR DESCRIPTION
This pull request resolves a backend bug where Instagram DM background automation tasks were randomly failing and retrying due to leftover testing logic. I have completely removed the Math.random() < 0.2 rate-limit simulation block from the sendInstagramDM function within services/dmQueueService.js. The BullMQ worker will now process actual DM tasks reliably without artificially dropping 20% of its workload.

Closes #292 