### PR TITLE
Fix/dashboard charts data

### DIFF
--- a/view/dashboard.ejs
+++ b/view/dashboard.ejs
@@ -1637,10 +1637,10 @@
                 new Chart(ctxClicks, {
                     type: 'line',
                     data: {
-                        labels: ['18 May', '19 May', '20 May', '21 May', '22 May', '23 May', '24 May'],
+                        labels: <%- JSON.stringify(dashboardData.charts.clicksOverview.labels) %>,
                         datasets: [{
                             label: 'Clicks',
-                            data: [100, 180, 220, 160, 300, 250, 423],
+                            data: <%- JSON.stringify(dashboardData.charts.clicksOverview.data) %>,
                             borderColor: '#000000',
                             backgroundColor: '#4338CA',
                             borderWidth: 4,
@@ -1669,9 +1669,9 @@
                 new Chart(ctxRef, {
                     type: 'doughnut',
                     data: {
-                        labels: ['Direct', 'Google', 'Twitter'],
+                        labels: <%- JSON.stringify(dashboardData.charts.topReferrers.labels) %>,
                         datasets: [{
-                            data: [65, 20, 15],
+                            data: <%- JSON.stringify(dashboardData.charts.topReferrers.data) %>,
                             backgroundColor: ['#4338CA', '#F59E0B', '#10B981'],
                             borderColor: '#000000',
                             borderWidth: 2,

--- a/view/dashboard.ejs
+++ b/view/dashboard.ejs
@@ -1633,14 +1633,17 @@
         document.addEventListener('DOMContentLoaded', () => {
             // Charts initialization with neo-brutalist styling
             const ctxClicks = document.getElementById('clicksChart');
+            const clicksLabels = JSON.parse('<%- JSON.stringify(dashboardData.charts.clicksOverview.labels) %>');
+            const clicksData = JSON.parse('<%- JSON.stringify(dashboardData.charts.clicksOverview.data) %>');
+            
             if (ctxClicks) {
                 new Chart(ctxClicks, {
                     type: 'line',
                     data: {
-                        labels: <%- JSON.stringify(dashboardData.charts.clicksOverview.labels) %>,
+                        labels: clicksLabels,
                         datasets: [{
                             label: 'Clicks',
-                            data: <%- JSON.stringify(dashboardData.charts.clicksOverview.data) %>,
+                            data: clicksData,
                             borderColor: '#000000',
                             backgroundColor: '#4338CA',
                             borderWidth: 4,
@@ -1665,13 +1668,16 @@
             }
 
             const ctxRef = document.getElementById('referrersChart');
+            const refLabels = JSON.parse('<%- JSON.stringify(dashboardData.charts.topReferrers.labels) %>');
+            const refData = JSON.parse('<%- JSON.stringify(dashboardData.charts.topReferrers.data) %>');
+            
             if (ctxRef) {
                 new Chart(ctxRef, {
                     type: 'doughnut',
                     data: {
-                        labels: <%- JSON.stringify(dashboardData.charts.topReferrers.labels) %>,
+                        labels: refLabels,
                         datasets: [{
-                            data: <%- JSON.stringify(dashboardData.charts.topReferrers.data) %>,
+                            data: refData,
                             backgroundColor: ['#4338CA', '#F59E0B', '#10B981'],
                             borderColor: '#000000',
                             borderWidth: 2,


### PR DESCRIPTION
This pull request resolves a frontend bug where the main user dashboard analytics charts were stuck displaying hardcoded mockup data. I modified the bottom of view/dashboard.ejs to replace the static labels and data arrays inside the clicksChart and referrersChart configurations. They now use EJS <%- JSON.stringify(...) %> tags to directly inject dashboardData.charts.clicksOverview and dashboardData.charts.topReferrers properties provided by the controller. Users will now see their accurate, real-time link click statistics and referral sources.

Closes #294 