### PR TITLE
fix: wire up handleGenerateShortUrlRender controller to URL shortener form route

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -348,6 +348,7 @@ const handleGetAnalytics = asyncHandler(async (req, res) => {
 module.exports = {
     handleRenderDashboard,
     handleGenerateShortUrl,
+    handleGenerateShortUrlRender,
     handleGetQRCode,
     handleDownloadQRCode,
     handleUpdateQRColors,

--- a/index.js
+++ b/index.js
@@ -492,21 +492,8 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
 
 const { isValidUrl } = require('./utils/validators');
 
-app.post('/services/url-shortener/shorten', protect, preventContributorWrites, urlShortenerLimiter, async (req, res) => {
-    const { redirectUrl } = req.body;
-    if (!redirectUrl || !isValidUrl(redirectUrl)) {
-        return res.render('home', buildShortenerViewModel(req, null, 'Please enter a valid HTTP or HTTPS URL.'));
-    }
-
-    try {
-        const shortId = shortid();
-        await Url.create({ shortId, redirectUrl });
-        return res.render('home', buildShortenerViewModel(req, shortId));
-    } catch (err) {
-        console.error('Error creating short URL:', err);
-        return res.render('home', buildShortenerViewModel(req, null, 'An unexpected error occurred.'));
-    }
-});
+const { handleGenerateShortUrlRender } = require('./controller/url');
+app.post('/services/url-shortener/shorten', protect, preventContributorWrites, urlShortenerLimiter, handleGenerateShortUrlRender);
 
 // ── FILE UPLOAD POST ──
 


### PR DESCRIPTION
This pull request resolves the backend integration disconnect for the URL shortener feature. It exports the complete handleGenerateShortUrlRender function from controller/url.js and wires it directly into the app.post('/services/url-shortener/shorten') route in index.js, replacing the incomplete inline logic. This simple integration ensures that form submissions from the dashboard UI now properly process the campaign name, generate customized QR codes, and re-render the dashboard with all intended features intact.

Closes #300 