### PR TITLE
fix(backend): clean up uploaded temp files to prevent DoS via disk exhaustion

### DIFF
--- a/index.js
+++ b/index.js
@@ -503,12 +503,22 @@ app.post('/services/file-upload/upload', protect, preventContributorWrites, uplo
     if (!req.file) {
         return res.status(400).json({ error: 'No file uploaded' });
     }
-    return res.json({
+
+    res.json({
         filename: req.file.originalname,
         size: req.file.size,
         mimetype: req.file.mimetype,
         path: req.file.filename,
     });
+
+    // Clean up temporary file to prevent DoS via disk exhaustion
+    try {
+        fs.unlink(req.file.path, (err) => {
+            if (err) console.error(`[upload] Failed to delete temp file ${req.file.path}:`, err);
+        });
+    } catch (e) {
+        console.error(`[upload] Error deleting temp file:`, e);
+    }
 });
 
 // ── SHORT URL REDIRECT ──


### PR DESCRIPTION
This pull request mitigates a severe backend vulnerability regarding uncontrolled disk space exhaustion. The /services/file-upload/upload route in index.js has been updated so that immediately after successfully responding to the client with the required file metadata, the server seamlessly executes an asynchronous fs.unlink() command. This ensures the raw temporary file in /tmp is immediately deleted, preventing orphaned files from accumulating and crashing the server. A try/catch block was additionally wrapped around the cleanup function to securely log any anomalous deletion errors without crashing the endpoint thread.

Closes #316 