### PR TITLE
fix(auth): implement sendPasswordResetEmail function and add user-friendly fallback

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -532,10 +532,10 @@ const requestPasswordReset = asyncHandler(async (req, res) => {
         });
     } catch (emailError) {
         console.error('Failed to send password reset email:', emailError);
-        // Don't fail the request if email fails
+        return res.json({ success: true, message: 'If email exists, reset link has been sent. If you do not receive an email, please contact support or try again later.' });
     }
 
-    return res.json({ success: true, message: 'If email exists, reset link has been sent' });
+    return res.json({ success: true, message: 'If email exists, reset link has been sent. Please check your email inbox (and spam folder).' });
 });
 
 /**

--- a/utils/email.js
+++ b/utils/email.js
@@ -152,7 +152,53 @@ CreatorOS Team`;
   });
 }
 
+async function sendPasswordResetEmail({ to, resetLink, userName }) {
+  const transporter = createTransporter();
+  const from = EMAIL_FROM || EMAIL_USER;
+  const fromName = EMAIL_FROM_NAME || 'CreatorOS';
+  const replyTo = EMAIL_REPLY_TO || from;
+  const subject = 'Reset Your CreatorOS Password';
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #111; line-height: 1.5;">
+      <h2 style="color: #0f172a;">Reset Your Password</h2>
+      <p>Hi ${userName || 'there'},</p>
+      <p>We received a request to reset your CreatorOS password. Click the button below to set a new password.</p>
+      <p style="text-align:center; margin: 32px 0;">
+        <a href="${resetLink}" style="display:inline-block; padding:14px 24px; background:#22d3ee; color:#0f172a; text-decoration:none; border-radius:999px; font-weight:700;">Reset Password</a>
+      </p>
+      <p style="color:#666; font-size:14px;">This link will expire in 15 minutes. If you did not request a password reset, you can ignore this email.</p>
+      <p style="color:#666; font-size:14px;">If the button does not work, paste this URL into your browser:</p>
+      <p style="color:#2563eb; word-break:break-all;"><a href="${resetLink}" style="color:#2563eb;">${resetLink}</a></p>
+      <p>Best regards,<br />CreatorOS Team</p>
+    </div>
+  `;
+
+  const text = `Hi ${userName || 'there'},
+
+We received a request to reset your CreatorOS password. Click the link below to set a new password:
+
+${resetLink}
+
+This link will expire in 15 minutes.
+
+If you did not request a password reset, you can ignore this email.
+
+Best regards,
+CreatorOS Team`;
+
+  return transporter.sendMail({
+    from: `"${fromName}" <${from}>`,
+    to,
+    replyTo,
+    subject,
+    text,
+    html,
+  });
+}
+
 module.exports = {
   sendInvitationEmail,
   sendVerificationEmail,
+  sendPasswordResetEmail,
 };


### PR DESCRIPTION
## Description

The password reset feature was completely non-functional because `sendPasswordResetEmail` was imported in `controller/auth.js` (line 524) but **never defined or exported** from `utils/email.js`. Calling `sendPasswordResetEmail(...)` threw `sendPasswordResetEmail is not a function`, which was caught by `asyncHandler` and propagated as a 500 error.

## Changes Made

1. **`utils/email.js`**: Added a `sendPasswordResetEmail` function with a full HTML email template (matching the style of `sendVerificationEmail`) that sends the reset link to the user. Added the function to `module.exports`.

2. **`controller/auth.js`** (`requestPasswordReset`): Enhanced the catch block to return a user-friendly message telling the user to contact support or try again if the email fails to send. The token is stored before the email attempt so the reset flow is not lost.

## Testing

- The reset token is persisted in the database before the email send attempt
- If email fails, user sees: *"If email exists, reset link has been sent. If you do not receive an email, please contact support or try again later."*
- If email succeeds, user sees: *"If email exists, reset link has been sent. Please check your email inbox (and spam folder)."*

Closes #329