### PR TITLE
fix(dashboard): filter URLs by userId to prevent data leak

### DIFF
--- a/model/url.js
+++ b/model/url.js
@@ -21,6 +21,7 @@ const urlSchema = new mongoose.Schema({
     userId: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User',
+        index: true,
     },
     totalClicks: {
         type: Number,

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,24 @@
+process.env.USE_MOCK_DB = "true";
+const mongoose = require('mongoose');
+const { getDashboardData } = require('../utils/dashboardHelper');
+const Url = require('../model/url');
+
+describe('Dashboard Data Isolation', () => {
+    it('should not show User B URLs when fetching dashboard data for User A', async () => {
+        const userAId = new mongoose.Types.ObjectId();
+        const userBId = new mongoose.Types.ObjectId();
+
+        await Url.create({ shortId: 'user-a-link', redirectUrl: 'https://a.com', userId: userAId });
+        await Url.create({ shortId: 'user-b-link', redirectUrl: 'https://b.com', userId: userBId });
+
+        const userADoc = { _id: userAId, createdAt: new Date() };
+        const data = await getDashboardData(userADoc);
+
+        const userBLink = data.recentLinks.find(l => l.shortUrl === 'user-b-link');
+        expect(userBLink).toBeUndefined();
+
+        const userALink = data.recentLinks.find(l => l.shortUrl === 'user-a-link');
+        expect(userALink).toBeDefined();
+        expect(userALink.originalUrl).toBe('https://a.com');
+    });
+});

--- a/utils/dashboardHelper.js
+++ b/utils/dashboardHelper.js
@@ -15,7 +15,8 @@ const Url = require('../model/url');
  * @returns {Promise<void>|void}
  */
 async function getDashboardData(userDoc) {
-    let urlsQuery = Url.find({});
+    const userId = userDoc ? userDoc._id : null;
+    let urlsQuery = userId ? Url.find({ userId }) : Url.find({ _id: null });
     let allUrls = await urlsQuery;
 
     // Handle Mongoose Query vs Mock implementation differences


### PR DESCRIPTION
## Description

The `getDashboardData` function in `utils/dashboardHelper.js` was fetching **every URL document in the database** (`Url.find({})`) without any user-specific filtering. This meant every authenticated user could see every other user's short URLs, redirect URLs, click counts, and analytics on their dashboard.

## Changes Made

1. **`utils/dashboardHelper.js`**: Changed `Url.find({})` to `Url.find({ userId })` — filtering by the authenticated user's `_id`. Guest contributors (no userDoc) get an empty result.

2. **`model/url.js`**: Added a database index on the `userId` field for efficient per-user queries.

3. **`tests/dashboard.test.js`**: Added a data isolation test that verifies User A cannot see User B's URLs in their dashboard data.

## Security Impact

- Users now only see their own URLs on the dashboard
- Dashboard stats (total links, total clicks) are now per-user, not system-wide
- Guest contributors see empty results instead of all URLs

Closes #330