### PR TITLE
fix(auth): remove auto-verification on login and fix Google OAuth verified status

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -248,7 +248,6 @@ const login = asyncHandler(async (req, res, next) => {
         return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
 
-    user.isVerified = true;
     user.lastLoginAt = new Date();
     await user.save();
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -50,7 +50,7 @@ const protect = async (req, res, next) => {
                 return res.redirect("/login");
             }
 
-            if (!user.isVerified) {
+            if (!user.isVerified && user.authProvider !== 'google') {
                 return res.status(403).redirect("/resend-verification");
             }
         }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -52,11 +52,13 @@ if (googleAuthConfigured) {
                         user.avatar = googleUser.avatar || user.avatar;
                         user.authProvider = user.password ? user.authProvider : "google";
                         user.lastLoginAt = googleUser.lastLoginAt;
+                        user.isVerified = true;
                         await user.save();
                     } else {
                         user = await User.create({
                             ...googleUser,
                             authProvider: "google",
+                            isVerified: true,
                         });
                     }
 


### PR DESCRIPTION
## Description

Two related authentication bugs:

1. **Login auto-verifies email**: The `login` handler in `controller/auth.js` unconditionally set `user.isVerified = true` on every successful login, completely bypassing the email verification flow.

2. **Google OAuth users permanently locked out**: Google-authenticated users were created with `isVerified: false` (implicit default), but they have no local password to resend verification, so the `protect` middleware permanently blocked them from all protected routes.

## Changes Made

1. **`controller/auth.js`** (`login`): Removed the `user.isVerified = true` line. Email verification now only happens through the `verifyEmail` endpoint.

2. **`routes/auth.js`** (Google Strategy): Explicitly set `isVerified: true` when creating new Google users and when updating existing users during Google sign-in, since Google has already verified the email.

3. **`middleware/auth.js`** (`protect`): Added `user.authProvider !== 'google'` exception so Google-authenticated users are not redirected to `/resend-verification` (which they can't use).

Closes #331