### PR TITLE
fix(ui): remove duplicated CSS rules and layout conflicts in home view

### DIFF
--- a/view/home.ejs
+++ b/view/home.ejs
@@ -67,7 +67,6 @@
             margin: 0;
             padding: 0;
         }
-        * { box-sizing: border-box; }
 
         body {
             font-family: 'Inter', sans-serif;
@@ -81,7 +80,6 @@
             color: inherit;
             text-decoration: none;
         }
-        a { color: inherit; }
 
         /* Headings & Typography */
         h1, h2, h3, h4, .brand-text, .title-font {
@@ -101,7 +99,6 @@
         .dashboard-layout.sidebar-collapsed {
             --sidebar-width: 80px;
         }
-        .dashboard-layout.sidebar-collapsed { --sidebar-width: 88px; }
 
         /* ── Sidebar Redesign ── */
         .sidebar {
@@ -179,7 +176,6 @@
             gap: 0.4rem;
             margin-bottom: 2rem;
         }
-        .sidebar-section { display: grid; gap: 0.45rem; }
 
         .sidebar-label {
             padding-left: 0.5rem;
@@ -226,11 +222,6 @@
             flex-shrink: 0;
             stroke: currentColor;
             fill: none;
-        }
-        .nav-link:hover, .service-link:hover {
-            transform: translateX(4px);
-            color: #67e8f9;
-            background: rgba(34, 211, 238, 0.08);
         }
 
         .sidebar-footer {
@@ -300,10 +291,6 @@
         .nav-icon { width: 1.25rem; height: 1.25rem; flex: 0 0 auto; }
         .service-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-        .sidebar-footer { margin-top: auto; display: grid; gap: 0.65rem; }
-
-        .dashboard-layout.sidebar-collapsed .brand { justify-content: center; padding-inline: 0; }
-
         .dashboard-layout.sidebar-collapsed .brand > span:not(.brand-mark),
         .dashboard-layout.sidebar-collapsed .sidebar-label,
         .dashboard-layout.sidebar-collapsed .service-name { display: none; }
@@ -320,8 +307,8 @@
             min-width: 0;
             display: flex;
             flex-direction: column;
+            animation: fadeIn 0.65s ease 0.1s both;
         }
-        .main { min-width: 0; animation: fadeIn 0.65s ease 0.1s both; }
 
         /* Shared Top Navigation */
         .topbar {
@@ -419,8 +406,6 @@
             background: rgba(34, 211, 238, 0.1);
         }
 
-        .topbar-actions { display: flex; align-items: center; gap: 0.75rem; }
-
         .profile-chip {
             display: inline-flex;
             align-items: center;
@@ -436,8 +421,6 @@
             transform: translate(-1px, -1px);
             box-shadow: 3px 3px 0px var(--border);
         }
-
-        .profile-chip:hover { transform: translateY(-2px); background: rgba(34, 211, 238, 0.1); }
 
         .avatar {
             width: 1.6rem;
@@ -489,8 +472,6 @@
         }
         .profile-name { font-weight: 700; }
 
-        .content { padding: 2.2rem 2.4rem 2.8rem; }
-
         .dashboard-head {
             display: flex;
             justify-content: space-between;
@@ -513,7 +494,6 @@
             font-size: 0.95rem;
             color: var(--muted-2);
         }
-        .dashboard-head p { margin: 0; color: var(--muted); font-size: 1.05rem; }
 
         .primary-action {
             display: inline-flex;
@@ -548,13 +528,6 @@
             flex-direction: column;
             position: relative;
             transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-        .stat-card, .panel {
-            border: 1px solid var(--border);
-            border-radius: 0.9rem;
-            background: var(--surface);
-            backdrop-filter: blur(18px);
-            box-shadow: var(--shadow);
         }
 
         .stat-card-retro:hover {
@@ -599,9 +572,6 @@
             line-height: 1;
             margin-bottom: 0.25rem;
         }
-        .stat-card:nth-child(2) { animation-delay: 0.05s; }
-        .stat-card:nth-child(3) { animation-delay: 0.1s; }
-        .stat-card:nth-child(4) { animation-delay: 0.15s; }
 
         .stat-card-retro .subtext {
             font-size: 0.78rem;
@@ -681,15 +651,6 @@
             font-weight: 700;
             color: #111111;
         }
-        .stat-icon.purple  { color: #67e8f9; background: rgba(34, 211, 238, 0.12); }
-        .stat-icon.blue    { color: #38bdf8; background: rgba(56, 189, 248, 0.12); }
-        .stat-icon.green   { color: #86efac; background: rgba(34, 197, 94, 0.12); }
-        .stat-icon.orange  { color: #fcd34d; background: rgba(245, 158, 11, 0.14); }
-
-        .stat-content h3   { margin: 0 0 0.45rem; color: var(--muted); font-size: 0.95rem; font-weight: 600; }
-        .stat-value        { margin: 0; font-size: 1.75rem; font-weight: 800; letter-spacing: 0; }
-        .stat-note         { grid-column: 1 / -1; margin: 0.1rem 0 0; color: var(--muted); font-size: 0.9rem; }
-        .trend             { color: var(--green); font-weight: 700; }
 
         .status-card-retro.pending {
             background-color: var(--accent-yellow);
@@ -698,7 +659,6 @@
         .status-card-retro.accepted {
             background-color: var(--success);
         }
-        .panel { padding: 1.35rem; animation: enterUp 0.62s ease 0.18s both; }
 
         .status-card-retro.expired {
             background-color: var(--accent-red);
@@ -722,15 +682,11 @@
             }
         }
 
-        /* Invite Section */
         .invite-panel p {
             font-size: 0.85rem;
             color: var(--muted);
             line-height: 1.5;
         }
-        .panel h2 { margin: 0; font-size: 1.25rem; letter-spacing: 0; }
-
-        .invite-panel p { margin: 0; color: var(--muted); line-height: 1.7; }
 
         .invite-form {
             display: flex;
@@ -786,11 +742,6 @@
             color: var(--white);
         }
 
-        .invite-form button:hover { transform: translateY(-1px); }
-
-        .message-box { padding: 1rem 1.15rem; border-radius: 0.95rem; margin-top: 1rem; font-size: 0.95rem; }
-        .message-success { background: rgba(34, 197, 94, 0.12); border: 1px solid rgba(34, 197, 94, 0.18); color: #d1fae5; }
-        .message-error   { background: rgba(248, 113, 113, 0.12); border: 1px solid rgba(248, 113, 113, 0.22); color: #fee2e2; }
 
         /* Donut Layout */
         .donut-layout {


### PR DESCRIPTION
This PR cleans up the embedded <style> block in view/home.ejs by systematically removing all redundant and overriding CSS declarations. By consolidating inconsistent rules—with a specific focus on structural classes like .content, .dashboard-layout.sidebar-collapsed, and the stat-card / panel variations—this fix restores UI stability, slims down the page weight, and guarantees predictable, responsive rendering moving forward.

Closes #338 