### PR TITLE
fix(suggestions): handle validation errors and show toast on failure

### DIFF
--- a/controller/suggestionController.js
+++ b/controller/suggestionController.js
@@ -78,7 +78,7 @@ async function generateAISuggestions(topic) {
 
 exports.getPage = (req, res) => {
   // We no longer need static categories
-  res.render('suggestions', { categories: [], result: null, selected: null, services });
+  res.render('suggestions', { categories: [], result: null, selected: null, error: null, services });
 };
 
 const { suggestionSchema } = require('../middleware/validators');
@@ -86,12 +86,17 @@ const { suggestionSchema } = require('../middleware/validators');
 exports.getSuggestions = asyncHandler(async (req, res, next) => {
   const validationResult = suggestionSchema.safeParse(req.body);
   if (!validationResult.success) {
-    return res.render('suggestions', { categories: [], result: null, selected: null, services });
+    const errorMsg = validationResult.error.errors[0]?.message || 'Invalid input provided.';
+    return res.render('suggestions', { categories: [], result: null, selected: null, error: errorMsg, services });
   }
 
   const { topic } = validationResult.data;
 
-  const result = await generateAISuggestions(topic);
-  
-  res.render('suggestions', { categories: [], result, selected: topic, services });
+  try {
+    const result = await generateAISuggestions(topic);
+    res.render('suggestions', { categories: [], result, selected: topic, error: null, services });
+  } catch (err) {
+    console.error('Error generating suggestions:', err);
+    res.render('suggestions', { categories: [], result: null, selected: topic, error: 'An unexpected error occurred while generating suggestions.', services });
+  }
 });

--- a/view/suggestions.ejs
+++ b/view/suggestions.ejs
@@ -812,6 +812,19 @@
 <!-- Toast -->
 <div class="toast" id="toast"></div>
 
+<% if (typeof error !== 'undefined' && error) { %>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const t = document.getElementById('toast');
+    if (t) {
+      t.textContent = "<%= error %>";
+      t.classList.add('show');
+      setTimeout(() => t.classList.remove('show'), 3500);
+    }
+  });
+</script>
+<% } %>
+
 <script>
   // ── PLATFORM TOGGLE ──
   function togglePlatform(el) {


### PR DESCRIPTION
This PR resolves the silent failure loop in the AI Suggestions feature by gracefully passing meaningful error strings back to the res.render() payload whenever validation (or AI generation) fails in the suggestionController. We've also updated the suggestions.ejs frontend template to parse any incoming server-side errors and instantly display them as a highly visible, automated toast notification upon page load, drastically improving user feedback and overall UX.