### PR TITLE
fix(security): TOCTOU race condition in URL shortener + missing ownership checks on QR endpoints

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -98,14 +98,22 @@ async function handleGenerateShortUrl(req, res) {
     const allowedTags = ['active', 'social', 'campaign', 'general'];
     const linkTag = allowedTags.includes(tag) ? tag : 'active';
 
-    const entry = await Url.create({
-        shortId,
-        redirectUrl,
-        userId: req.user?.id || null,
-        title: deriveTitle(redirectUrl, title?.trim()),
-        tag: linkTag,
-        linkedAt: new Date(),
-    });
+    let entry;
+    try {
+        entry = await Url.create({
+            shortId,
+            redirectUrl,
+            userId: req.user?.id || null,
+            title: deriveTitle(redirectUrl, title?.trim()),
+            tag: linkTag,
+            linkedAt: new Date(),
+        });
+    } catch (err) {
+        if (err.code === 11000) {
+            return res.status(409).json({ error: 'That slug is already taken. Try another.' });
+        }
+        return res.status(500).json({ error: 'Failed to create short URL. Please try again.' });
+    }
 
     const hostBase = `${req.protocol}://${req.get('host')}`;
 
@@ -268,6 +276,10 @@ const handleGetQRCode = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
     }
 
+    if (entry.userId?.toString() !== req.user?.id) {
+        return res.status(403).json({ success: false, message: "Not your URL", error: "Not your URL" });
+    }
+
     const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
     const shortUrl = `${baseUrl}/u/${shortId}`;
 
@@ -301,6 +313,10 @@ const handleDownloadQRCode = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
     }
 
+    if (entry.userId?.toString() !== req.user?.id) {
+        return res.status(403).json({ success: false, message: "Not your URL", error: "Not your URL" });
+    }
+
     const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
     const shortUrl = `${baseUrl}/u/${shortId}`;
 
@@ -325,6 +341,16 @@ const handleDownloadQRCode = asyncHandler(async (req, res) => {
 const handleUpdateQRColors = asyncHandler(async (req, res) => {
     const { shortId } = req.params;
     const { qrFgColor, qrBgColor } = req.body;
+
+    const entry = await Url.findOne({ shortId });
+
+    if (!entry) {
+        return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
+    }
+
+    if (entry.userId?.toString() !== req.user?.id) {
+        return res.status(403).json({ success: false, message: "Not your URL", error: "Not your URL" });
+    }
 
     const updated = await Url.findOneAndUpdate(
         { shortId },

--- a/routes/url.js
+++ b/routes/url.js
@@ -105,25 +105,9 @@ router.post('/', protect, preventContributorWrites, urlShortenerApiLimiter, shor
  *       500:
  *         description: Internal server error
  */
-router.get('/qr/:shortId/download', handleDownloadQRCode);      
+router.get('/qr/:shortId/download', protect, handleDownloadQRCode);      
 
-/**
- * @swagger
- * /qr/:shortId:
- *   get:
- *     summary: GET request for /qr/:shortId
- *     description: Retrieves the QR code image for a specific shortened URL.
- *     responses:
- *       200:
- *         description: Successful response
- *       400:
- *         description: Bad request
- *       401:
- *         description: Unauthorized
- *       500:
- *         description: Internal server error
- */
-router.get('/qr/:shortId',          handleGetQRCode);       
+router.get('/qr/:shortId',          protect, handleGetQRCode);
 
 /**
  * @swagger


### PR DESCRIPTION
## Fixes #350

### Changes Made

**1. TOCTOU race condition in slug creation (`controller/url.js`)**
- Wrapped `Url.create()` in a try-catch block that gracefully handles MongoDB E11000 duplicate key errors
- Returns HTTP 409 (conflict) when a concurrent request creates the same slug first, instead of crashing the server with a 500

**2. Missing auth middleware on QR routes (`routes/url.js`)**
- Added `protect` middleware to `GET /qr/:shortId/download` (was completely unauthenticated)
- Added `protect` middleware to `GET /qr/:shortId` (was completely unauthenticated)

**3. Missing ownership checks on QR controllers (`controller/url.js`)**
- Added `entry.userId?.toString() !== req.user?.id` check in `handleGetQRCode`
- Added the same ownership check in `handleDownloadQRCode`
- Added the same ownership check in `handleUpdateQRColors`
- All return HTTP 403 with `"Not your URL"` if the requester doesn't own the URL