### PR TITLE
fix(security): use nonce-based CSP script-src instead of unsafe-inline/unsafe-eval

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,14 +50,12 @@ app.set("view engine", "ejs");
 app.set('views', path.join(__dirname, 'view'));
 app.locals.BRAND = BRAND;
 
-// Content Security Policy (CSP) header - defense-in-depth against XSS
-app.use((req, res, next) => {
-    res.setHeader(
-        'Content-Security-Policy',
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'none';"
-    );
-    next();
-});
+// Content Security Policy (CSP) header - defense-in-depth against XSS.
+// Uses a per-request nonce for script-src instead of 'unsafe-inline'/
+// 'unsafe-eval', so injected scripts (e.g. via a stored XSS payload) can't
+// execute even if they land in the page, while legitimate inline scripts
+// (marked with the matching nonce) still run. See middleware/csp.js.
+app.use(require('./middleware/csp'));
 
 const rateLimit = require('express-rate-limit');
 

--- a/middleware/csp.js
+++ b/middleware/csp.js
@@ -1,0 +1,28 @@
+const crypto = require('crypto');
+
+// Generates a fresh per-request nonce and sets a nonce-based CSP header.
+// 'unsafe-inline'/'unsafe-eval' let any injected <script> tag run, which
+// defeats the purpose of CSP as an XSS mitigation. A per-request nonce lets
+// legitimate inline scripts (marked with the matching nonce attribute) run
+// while blocking anything an attacker injects, since they can't predict it.
+function csp(req, res, next) {
+    res.locals.nonce = crypto.randomBytes(16).toString('base64');
+
+    res.setHeader(
+        'Content-Security-Policy',
+        [
+            "default-src 'self'",
+            `script-src 'self' 'nonce-${res.locals.nonce}' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com`,
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+            "font-src 'self' https://fonts.gstatic.com",
+            "img-src 'self' data: https:",
+            "connect-src 'self' https:",
+            "frame-ancestors 'none'",
+            "object-src 'none'",
+        ].join('; ')
+    );
+
+    next();
+}
+
+module.exports = csp;

--- a/view/analytics-dashboard.ejs
+++ b/view/analytics-dashboard.ejs
@@ -1517,7 +1517,7 @@
         </main>
     </div>
 
-    <script>
+    <script nonce="<%= nonce %>">
         const sidebarToggle = document.getElementById('sidebarToggle');
         const dashboardLayout = document.getElementById('dashboardLayout');
         

--- a/view/analytics.ejs
+++ b/view/analytics.ejs
@@ -684,7 +684,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="<%= nonce %>">
   // Engagement bar chart
   const ctx = document.getElementById('engagementChart');
   const engagementData = {

--- a/view/bio-builder.ejs
+++ b/view/bio-builder.ejs
@@ -107,7 +107,7 @@
 
 </div>
 
-<script>
+<script nonce="<%= nonce %>">
 
 const titleInput =
     document.getElementById('bio-title');

--- a/view/bio-editor.ejs
+++ b/view/bio-editor.ejs
@@ -619,7 +619,7 @@
 
 <div class="toast" id="toast">✓ Saved!</div>
 
-<script>
+<script nonce="<%= nonce %>">
   let links = [];
   let linkIdCounter = 0;
   let currentTheme = 'light';

--- a/view/bio-profile.ejs
+++ b/view/bio-profile.ejs
@@ -558,7 +558,7 @@
 <!-- TOAST -->
 <div class="toast" id="toast">Link opened!</div>
 
-<script>
+<script nonce="<%= nonce %>">
   // Theme
   function setTheme(theme, btn) {
     document.documentElement.setAttribute('data-theme', theme);

--- a/view/dashboard.ejs
+++ b/view/dashboard.ejs
@@ -1626,7 +1626,7 @@
 
     <script src="/js/pages/dashboard.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script>
+    <script nonce="<%= nonce %>">
         document.addEventListener('DOMContentLoaded', () => {
             // Charts initialization with neo-brutalist styling
             const ctxClicks = document.getElementById('clicksChart');

--- a/view/dm-automation.ejs
+++ b/view/dm-automation.ejs
@@ -2231,7 +2231,7 @@
   </div>
 
   <!-- Client-Side Automation Logic -->
-  <script>
+  <script nonce="<%= nonce %>">
     // Global layout & sidebar toggles
     var layout = document.getElementById('dashboardLayout');
     var toggle = document.getElementById('sidebarToggle');

--- a/view/home.ejs
+++ b/view/home.ejs
@@ -1497,7 +1497,7 @@
     </div>
 
     <!-- Scripts -->
-    <script>
+    <script nonce="<%= nonce %>">
         const sidebarToggle = document.getElementById('sidebarToggle');
         const dashboardLayout = document.getElementById('dashboardLayout');
         
@@ -1543,7 +1543,7 @@
 
     <!-- QR Code Script (Pulled exactly from old home.ejs) -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-    <script>
+    <script nonce="<%= nonce %>">
         var qrState = {
             url: '<%= locals.shortUrl || "" %>',
             fgColor: '#1a1a1a',

--- a/view/my-links.ejs
+++ b/view/my-links.ejs
@@ -1757,7 +1757,7 @@
     <div class="toast" id="toast" role="status" aria-live="polite" style="display:none; position:fixed; bottom:20px; right:20px; background:var(--card-bg); border:var(--border-thick); padding:1rem; box-shadow:var(--shadow-retro); z-index:1000; font-weight:700;"></div>
 
     <script src="/js/pages/my-links.js"></script>
-    <script>
+    <script nonce="<%= nonce %>">
         const sidebarToggle = document.getElementById('sidebarToggle');
         const dashboardLayout = document.getElementById('dashboardLayout');
         const themeToggle = document.getElementById('theme-toggle');

--- a/view/signup.ejs
+++ b/view/signup.ejs
@@ -501,7 +501,7 @@
                             Create Account
                         </button>
 
-<script>
+<script nonce="<%= nonce %>">
     const signupForm = document.querySelector('form');
     let signupLoading = false;
 

--- a/view/suggestions.ejs
+++ b/view/suggestions.ejs
@@ -813,7 +813,7 @@
 <div class="toast" id="toast"></div>
 
 <% if (typeof error !== 'undefined' && error) { %>
-<script>
+<script nonce="<%= nonce %>">
   document.addEventListener('DOMContentLoaded', () => {
     const t = document.getElementById('toast');
     if (t) {
@@ -825,7 +825,7 @@
 </script>
 <% } %>
 
-<script>
+<script nonce="<%= nonce %>">
   // ── PLATFORM TOGGLE ──
   function togglePlatform(el) {
     el.classList.toggle('selected');

--- a/view/vault.ejs
+++ b/view/vault.ejs
@@ -632,7 +632,7 @@
   <span id="toastMsg">Link copied to clipboard!</span>
 </div>
 
-<script>
+<script nonce="<%= nonce %>">
   // Drag & drop
   const uploadZone = document.getElementById('uploadZone');
   const fileInput  = document.getElementById('fileInput');


### PR DESCRIPTION
## Summary

The existing Content-Security-Policy header (added in `index.js`) allowed `'unsafe-inline'` and `'unsafe-eval'` in `script-src`. That defeats CSP as an XSS mitigation: if an attacker successfully injects a `<script>` tag or event handler into the page, `unsafe-inline` lets it run anyway. This PR switches to a per-request nonce, matching the approach proposed in the issue.

## Related Issue

Closes #349

## Type of Change

- [x] Security fix
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update

## Changes Made

- **`middleware/csp.js`** (new): generates a random per-request nonce via `crypto.randomBytes(16).toString('base64')`, exposes it as `res.locals.nonce` for templates, and sets `Content-Security-Policy` with `script-src 'self' 'nonce-<value>' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com` (the three CDN origins the app already loads external scripts from). `unsafe-inline` and `unsafe-eval` are dropped entirely — I checked the codebase for `eval()`/`new Function()` usage and found none, so `unsafe-eval` wasn't needed in the first place.
- **`index.js`**: replaced the static CSP header middleware with `app.use(require('./middleware/csp'))`.
- **14 inline `<script>` tags** across the EJS views now carry `nonce="<%= nonce %>"` so they continue to execute under the stricter policy: `bio-builder.ejs`, `analytics.ejs`, `bio-editor.ejs`, `analytics-dashboard.ejs`, `bio-profile.ejs`, `dashboard.ejs`, `dm-automation.ejs`, `my-links.ejs`, `home.ejs` (x2), `vault.ejs`, `suggestions.ejs` (x2), `signup.ejs`. Script tags with a `src` attribute (e.g. `/js/pages/*.js`, CDN scripts) are unaffected — they're already allow-listed by origin, not by nonce.
- `style-src` keeps `'unsafe-inline'` as in the original policy (styles are a much lower-severity XSS vector than scripts, and the issue's own proposed solution keeps it too).

## Testing

- [x] `npm run build` (repo's `node --check` syntax validation) passes
- [x] `node -c` on the new middleware file and `index.js` — no syntax errors
- [x] Verified all 14 inline `<script>` tags now carry the nonce attribute and none were missed or double-patched
- [x] Confirmed no `eval()`/`new Function()` usage exists anywhere in the codebase before dropping `unsafe-eval`
- Note: this repo has no CI test/build workflow configured, so I validated locally with the checks above.

## Additional Notes

I see this issue is also assigned to @aaniya22 — happy to coordinate if there's overlapping work in progress. @aashutoshkumarbhardwaj could you review this and add the appropriate label if it looks good? Thanks!