### PR TITLE
feat(security): lock account after repeated failed login attempts

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -4,6 +4,7 @@ const crypto = require("crypto");
 const connectDB = require("../connect");
 const asyncHandler = require("../utils/asyncHandler");
 const { wantsHtml } = require("../utils/requestType");
+const { AccountLockedError, loginAttempts, resetAttempts } = require("../middleware/loginLockout");
 
 const CONTRIBUTOR_NAME = "Contributor";
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -230,23 +231,37 @@ const login = asyncHandler(async (req, res, next) => {
 
     const { email, password } = req.body || {};
     const normalizedEmail = (email && typeof email === 'string') ? email.toLowerCase().trim() : "";
-    
+
     if (!normalizedEmail || !password) {
         if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
         return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
 
+    try {
+        await loginAttempts.checkAttempts(normalizedEmail);
+    } catch (error) {
+        if (error instanceof AccountLockedError) {
+            if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(error.message));
+            return res.status(429).json({ success: false, message: error.message });
+        }
+        throw error;
+    }
+
     const user = await User.findOne({ email: normalizedEmail });
     if (!user) {
+        await loginAttempts.recordFailure(normalizedEmail);
         if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
         return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
 
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) {
+        await loginAttempts.recordFailure(normalizedEmail);
         if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
         return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
+
+    await loginAttempts.resetAttempts(normalizedEmail);
 
     user.lastLoginAt = new Date();
     await user.save();
@@ -500,11 +515,30 @@ const requestPasswordReset = asyncHandler(async (req, res) => {
         return res.status(400).json({ success: false, message: 'Email is required' });
     }
 
-    const user = await User.findOne({ email: email.toLowerCase().trim() });
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Cap repeated reset requests per email so the flow can't be used to
+    // enumerate accounts (timing/side-channel probing) or to spam a
+    // victim's inbox with reset emails. Always returns the same generic
+    // response regardless of lockout state, same as the "user not found"
+    // branch below, so a locked-out attacker learns nothing new.
+    try {
+        await resetAttempts.checkAttempts(normalizedEmail);
+    } catch (error) {
+        if (error instanceof AccountLockedError) {
+            return res.json({ success: true, message: 'If email exists, reset link has been sent' });
+        }
+        throw error;
+    }
+
+    const user = await User.findOne({ email: normalizedEmail });
     if (!user) {
+        await resetAttempts.recordFailure(normalizedEmail);
         // Don't reveal whether email exists for security
         return res.json({ success: true, message: 'If email exists, reset link has been sent' });
     }
+
+    await resetAttempts.recordFailure(normalizedEmail);
 
     // Create password reset token (15 minute validity)
     const resetToken = crypto.randomBytes(32).toString('hex');
@@ -582,6 +616,9 @@ const resetPassword = asyncHandler(async (req, res) => {
     resetTokenDoc.used = true;
     resetTokenDoc.usedAt = new Date();
     await resetTokenDoc.save();
+
+    await resetAttempts.resetAttempts(user.email);
+    await loginAttempts.resetAttempts(user.email);
 
     return res.json({ success: true, message: 'Password reset successfully. Please log in with your new password.' });
 });

--- a/middleware/loginLockout.js
+++ b/middleware/loginLockout.js
@@ -1,0 +1,107 @@
+const Redis = require('ioredis');
+
+// Tracks failed login/reset attempts per-identifier (not per-IP) so a
+// brute-force attempt spread across many IPs still gets locked out. Falls
+// back to an in-memory Map when REDIS_URI isn't configured, matching the
+// pattern used in controller/instagramController.js.
+const REDIS_URI = process.env.REDIS_URI || process.env.REDIS_URL;
+const redis = REDIS_URI
+    ? new Redis(REDIS_URI, {
+        connectTimeout: 5000,
+        lazyConnect: true,
+    })
+    : null;
+
+if (redis) {
+    redis.on('error', (error) => {
+        console.warn(`[LoginLockout] Redis error: ${error.message}`);
+    });
+}
+
+const memoryStore = new Map();
+
+function memoryGet(key) {
+    const entry = memoryStore.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+        memoryStore.delete(key);
+        return null;
+    }
+    return entry;
+}
+
+class AccountLockedError extends Error {
+    constructor(message, retryAfterSeconds) {
+        super(message);
+        this.name = 'AccountLockedError';
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}
+
+function buildAttemptTracker(prefix, maxAttempts, lockoutSeconds) {
+    const keyFor = (identifier) => `${prefix}:${identifier.toLowerCase().trim()}`;
+
+    async function checkAttempts(identifier) {
+        const key = keyFor(identifier);
+
+        if (redis) {
+            const attempts = parseInt(await redis.get(key) || '0', 10);
+            if (attempts >= maxAttempts) {
+                const ttl = await redis.ttl(key);
+                throw new AccountLockedError(
+                    `Account locked. Try again in ${Math.ceil(ttl / 60)} minutes.`,
+                    ttl > 0 ? ttl : lockoutSeconds
+                );
+            }
+            return;
+        }
+
+        const entry = memoryGet(key);
+        if (entry && entry.count >= maxAttempts) {
+            const ttl = Math.ceil((entry.expiresAt - Date.now()) / 1000);
+            throw new AccountLockedError(
+                `Account locked. Try again in ${Math.ceil(ttl / 60)} minutes.`,
+                ttl
+            );
+        }
+    }
+
+    async function recordFailure(identifier) {
+        const key = keyFor(identifier);
+
+        if (redis) {
+            const attempts = await redis.incr(key);
+            if (attempts === 1) await redis.expire(key, lockoutSeconds);
+            return attempts;
+        }
+
+        const entry = memoryGet(key) || { count: 0, expiresAt: Date.now() + lockoutSeconds * 1000 };
+        entry.count += 1;
+        memoryStore.set(key, entry);
+        return entry.count;
+    }
+
+    async function resetAttempts(identifier) {
+        const key = keyFor(identifier);
+        if (redis) {
+            await redis.del(key);
+            return;
+        }
+        memoryStore.delete(key);
+    }
+
+    return { checkAttempts, recordFailure, resetAttempts };
+}
+
+// 5 failed logins -> 15 minute lockout, tracked per email/username.
+const loginAttempts = buildAttemptTracker('login_attempts', 5, 15 * 60);
+
+// 5 password reset requests -> 15 minute cooldown, tracked per email.
+// Prevents using the reset flow to enumerate accounts or spam reset emails.
+const resetAttempts = buildAttemptTracker('reset_attempts', 5, 15 * 60);
+
+module.exports = {
+    AccountLockedError,
+    loginAttempts,
+    resetAttempts,
+};


### PR DESCRIPTION
## Summary

CreatorOs login had no brute-force protection. The existing rate limiter (`middleware/rateLimiters.js`) is IP-based, so an attacker distributing guesses across many IPs, or one behind a shared/NAT'd IP as many legitimate users, could still make effectively unlimited password guesses against a single account. This adds a per-account lockout on top of the existing IP limiter.

## Related Issue

Closes #347

## Type of Change

- [x] Security fix
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update

## Changes Made

- **`middleware/loginLockout.js`** (new): tracks failed attempts keyed by email in Redis, matching the connection pattern already used in `controller/instagramController.js` (`REDIS_URI` env var, `lazyConnect`), and falls back to an in-memory `Map` when Redis isn't configured so the feature still works in dev/mock mode. After 5 consecutive failures the identifier is locked for 15 minutes; the TTL is read back from Redis (or the in-memory entry) to report accurate remaining lockout time.
- **`controller/auth.js` `login()`**: checks the lockout before querying the user, records a failure on both the "no such user" and "wrong password" branches (so the response stays identical either way and doesn't leak which case occurred), and clears the counter on a successful login.
- **`controller/auth.js` `requestPasswordReset()`**: applies the same per-email counter to the reset-request flow, per the issue's additional context. Once locked, it silently returns the same generic "if email exists, reset link has been sent" message already used for the "user not found" case, so a locked-out caller learns nothing new and can't use response differences to enumerate accounts or spam a victim's inbox with reset emails.
- **`controller/auth.js` `resetPassword()`**: clears both the login and reset counters on a successful password reset.

## Testing

- [x] `npm run build` (repo's `node --check` syntax validation) passes
- [x] `node -c` on the new middleware and `controller/auth.js` — no syntax errors
- [x] Manually traced both the Redis-configured and in-memory-fallback code paths for check → record → reset
- [x] Verified failure responses on the "user not found" and "wrong password" branches remain textually identical (no new enumeration vector introduced)
- Note: this repo has no CI test/build workflow configured beyond the `node --check` script above, which passes.

## Additional Notes

@aashutoshkumarbhardwaj could you review this and add the appropriate label if it looks good? Thanks!