### PR TITLE
perf: cache creator profile lookups in Redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,17 @@ const asyncHandler = require('./utils/asyncHandler');
 
 const suggestionRoutes = require('./routes/suggestionRoutes');
 const { getDashboardData } = require('./utils/dashboardHelper');
+const { getCachedUserProfile } = require('./utils/creatorProfileCache');
+
+// Nearly every page route below re-fetches the signed-in creator's own User
+// document. Wrapping it here caches the result for PROFILE_TTL (5 min, see
+// utils/creatorProfileCache.js) and sets X-Cache so cache hits/misses are
+// visible in responses, per the issue's observability request.
+async function loadCreatorProfile(req, res) {
+    const { doc, hit } = await getCachedUserProfile(req.user.id, User);
+    res.setHeader('X-Cache', hit ? 'HIT' : 'MISS');
+    return doc;
+}
 
 app.use('/suggestions', protect, suggestionRoutes);
 app.use('/services/creator-crm', protect, collaborationRoutes);
@@ -283,9 +294,7 @@ app.get('/services', (req, res) => {
 app.get("/dashboard", protect, asyncHandler(async (req, res) => {
     const userDoc = isGuestContributor(req.user)
         ? null
-        : await User.findById(req.user.id)
-            .select('name email alias bio twoFactorEnabled preferences passwordChangedAt updatedAt subscription')
-            .lean();
+        : await loadCreatorProfile(req, res);
 
     const inviteSummary = isGuestContributor(req.user)
         ? buildEmptyInviteSummary()
@@ -316,7 +325,7 @@ app.get("/dashboard", protect, asyncHandler(async (req, res) => {
 app.get("/profile", protect, asyncHandler(async (req, res) => {
     const userDoc = isGuestContributor(req.user)
         ? null
-        : await User.findById(req.user.id).select('name email').lean();
+        : await loadCreatorProfile(req, res);
 
     res.render("profile", { user: buildAccountViewModel(userDoc, req.user) });
 }));
@@ -325,9 +334,7 @@ app.get("/profile", protect, asyncHandler(async (req, res) => {
 app.get('/settings', protect, asyncHandler(async (req, res) => {
     const userDoc = isGuestContributor(req.user)
         ? null
-        : await User.findById(req.user.id)
-            .select('name email alias bio twoFactorEnabled preferences passwordChangedAt updatedAt subscription')
-            .lean();
+        : await loadCreatorProfile(req, res);
 
     res.render('settings', {
         services,
@@ -340,9 +347,7 @@ app.get('/settings', protect, asyncHandler(async (req, res) => {
 app.get('/my-links', protect, asyncHandler(async (req, res) => {
     const userDoc = isGuestContributor(req.user)
         ? null
-        : await User.findById(req.user.id)
-            .select('name email alias bio twoFactorEnabled preferences passwordChangedAt updatedAt subscription')
-            .lean();
+        : await loadCreatorProfile(req, res);
 
     res.render('my-links', {
         services,
@@ -355,9 +360,7 @@ app.get('/my-links', protect, asyncHandler(async (req, res) => {
 
 // Analytics
 app.get('/analytics', protect, asyncHandler(async (req, res) => {
-    const userDoc = await User.findById(req.user.id)
-        .select('name email')
-        .lean();
+    const userDoc = await loadCreatorProfile(req, res);
 
     return res.render('analytics', {
         services,
@@ -371,9 +374,7 @@ app.get('/vault', protect, (req, res) => {
 });
 // File Upload page
 app.get('/file-upload', protect, asyncHandler(async (req, res) => {
-    const userDoc = await User.findById(req.user.id)
-        .select('name email')
-        .lean();
+    const userDoc = await loadCreatorProfile(req, res);
 
     return res.render('file-upload', {
         services,
@@ -385,9 +386,7 @@ app.get('/file-upload', protect, asyncHandler(async (req, res) => {
 
 // Editor — creator configures their bio page
 app.get('/bio', protect, asyncHandler(async (req, res) => {
-    const userDoc = await User.findById(req.user.id)
-        .select('name email alias bio')
-        .lean();
+    const userDoc = await loadCreatorProfile(req, res);
 
     return res.render('bio-editor', {
         services,
@@ -468,9 +467,7 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
     }
 
     if (service.key === 'analytics-dashboard') {
-        const userDoc = await User.findById(req.user.id)
-            .select('name email')
-            .lean();
+        const userDoc = await loadCreatorProfile(req, res);
 
         return res.render('analytics-dashboard', {
             service,
@@ -481,9 +478,7 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
     }
 
     if (service.key === 'smart-bio') {
-        const userDoc = await User.findById(req.user.id)
-            .select('name email alias bio')
-            .lean();
+        const userDoc = await loadCreatorProfile(req, res);
 
         return res.render('bio-editor', {
             service,

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const bcrypt = require('bcryptjs');
 const User = require('../model/user');
 const { preventContributorWrites } = require('../middleware/auth');
+const { invalidateProfileCache } = require('../utils/creatorProfileCache');
 
 const asyncHandler = fn => (req, res, next) =>
     Promise.resolve(fn(req, res, next)).catch(next);
@@ -76,6 +77,7 @@ router.put('/profile', preventContributorWrites, asyncHandler(async (req, res) =
     if (bio !== undefined) user.bio = bio;
     
     await user.save();
+    await invalidateProfileCache(user._id);
     res.json({
         message: 'Profile updated successfully',
         user: {
@@ -135,7 +137,8 @@ router.put('/security/2fa', preventContributorWrites, asyncHandler(async (req, r
     
     user.twoFactorEnabled = !!enabled;
     await user.save();
-    
+    await invalidateProfileCache(user._id);
+
     res.json({ message: '2FA settings updated successfully', twoFactorEnabled: user.twoFactorEnabled });
 }));
 
@@ -180,6 +183,7 @@ router.put('/security/password', preventContributorWrites, asyncHandler(async (r
     user.password = await bcrypt.hash(newPassword, salt);
     user.passwordChangedAt = new Date();
     await user.save();
+    await invalidateProfileCache(user._id);
 
     const days = daysSince(user.passwordChangedAt);
     res.json({
@@ -264,6 +268,7 @@ router.put('/preferences', asyncHandler(async (req, res) => {
     };
     
     await user.save();
+    await invalidateProfileCache(user._id);
     res.json({ message: 'Preferences updated successfully', preferences: user.preferences });
 }));
 

--- a/utils/creatorProfileCache.js
+++ b/utils/creatorProfileCache.js
@@ -1,0 +1,72 @@
+const Redis = require('ioredis');
+
+// Caches each creator's own profile document (fetched via User.findById on
+// nearly every page render - dashboard, analytics, bio editor, settings,
+// etc.) so repeat visits within the TTL window skip the DB round-trip.
+// Falls back to an in-memory Map when REDIS_URI isn't configured, matching
+// the pattern already used in controller/instagramController.js.
+const REDIS_URI = process.env.REDIS_URI || process.env.REDIS_URL;
+const redis = REDIS_URI
+    ? new Redis(REDIS_URI, {
+        connectTimeout: 5000,
+        lazyConnect: true,
+    })
+    : null;
+
+if (redis) {
+    redis.on('error', (error) => {
+        console.warn(`[CreatorProfileCache] Redis error: ${error.message}`);
+    });
+}
+
+const memoryStore = new Map();
+const PROFILE_TTL = 300; // 5 minutes
+
+function cacheKey(userId) {
+    return `profile:${userId}`;
+}
+
+/**
+ * Fetches a user's profile document, serving from cache when available.
+ * @param {string} userId
+ * @param {import('mongoose').Model} User - the User model (passed in to avoid a require cycle)
+ * @returns {Promise<{ doc: object|null, hit: boolean }>}
+ */
+async function getCachedUserProfile(userId, User) {
+    const key = cacheKey(userId);
+
+    if (redis) {
+        const cached = await redis.get(key);
+        if (cached) return { doc: JSON.parse(cached), hit: true };
+
+        const doc = await User.findById(userId).lean();
+        if (doc) await redis.setex(key, PROFILE_TTL, JSON.stringify(doc));
+        return { doc, hit: false };
+    }
+
+    const entry = memoryStore.get(key);
+    if (entry && entry.expiresAt > Date.now()) {
+        return { doc: entry.doc, hit: true };
+    }
+
+    const doc = await User.findById(userId).lean();
+    if (doc) memoryStore.set(key, { doc, expiresAt: Date.now() + PROFILE_TTL * 1000 });
+    return { doc, hit: false };
+}
+
+/**
+ * Invalidates a user's cached profile. Call after any write to the User
+ * document (settings updates, profile picture change, etc.) so the next
+ * read reflects the change instead of serving stale cached data.
+ * @param {string} userId
+ */
+async function invalidateProfileCache(userId) {
+    const key = cacheKey(userId);
+    if (redis) {
+        await redis.del(key);
+        return;
+    }
+    memoryStore.delete(key);
+}
+
+module.exports = { getCachedUserProfile, invalidateProfileCache };


### PR DESCRIPTION
## Summary

Nearly every page route in `index.js` — dashboard, settings, my-links, analytics, bio editor, file-upload, and the analytics-dashboard/smart-bio service routes — independently re-fetched the signed-in creator's own `User` document with `User.findById(req.user.id)` on every single request. That's the same document, re-fetched from MongoDB, for every page a creator visits, exactly the repetitive-identical-query pattern described in the issue.

## Related Issue

Closes #346

## Type of Change

- [x] Performance improvement
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update

## Changes Made

- **`utils/creatorProfileCache.js`** (new): `getCachedUserProfile(userId, User)` checks Redis first with a 5-minute TTL (matching the issue's proposed `PROFILE_TTL`), and on a miss fetches from Mongo and writes through to the cache. Falls back to an in-memory `Map` with the same TTL semantics when `REDIS_URI` isn't configured, matching the pattern already used in `controller/instagramController.js`. `invalidateProfileCache(userId)` clears a cached entry.
- **`index.js`**: added a `loadCreatorProfile(req, res)` helper that wraps the cache lookup and sets `X-Cache: HIT` or `X-Cache: MISS` on the response, per the issue's observability request. Replaced all 9 `User.findById(req.user.id)...lean()` call sites across the dashboard/settings/analytics/bio/file-upload routes with this helper. The various `.select(field, field, ...)` projections these calls used were dropped in favor of caching the full lean document — templates only read the fields they need, and caching the whole doc avoids needing a separate cache entry per distinct projection.
- **`routes/settings.js`**: call `invalidateProfileCache(user._id)` after each of the four `User`-mutating endpoints (`PUT /profile`, `PUT /security/2fa`, `PUT /security/password`, `PUT /preferences`) so a settings change is reflected on the very next page load instead of serving a stale cached profile for up to 5 minutes.

## Testing

- [x] `npm run build` (repo's `node --check` syntax validation) passes
- [x] `node -c` on all three changed/new files — no syntax errors
- [x] Ran the full Jest suite (`npx jest`) before and after my changes — same 1 pre-existing failure in `tests/controllers/url.test.js` both times (unrelated status-code assertion, confirmed present on `main` before my branch), no new failures introduced
- [x] `tests/dashboard.test.js` passes (exercises the `/dashboard` route I modified)

## Additional Notes

@aashutoshkumarbhardwaj could you review this and add the appropriate label if it looks good? Thanks!