### PR TITLE
feat: add content scheduling with timezone-aware publishing queue

### DIFF
--- a/controller/contentController.js
+++ b/controller/contentController.js
@@ -1,0 +1,91 @@
+const mongoose = require('mongoose');
+const asyncHandler = require('../utils/asyncHandler');
+const ScheduledContent = require('../model/scheduledContent');
+
+/**
+ * @function scheduleContent
+ * @description Creates a piece of content scheduled to auto-publish at a future UTC time.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+const scheduleContent = asyncHandler(async (req, res) => {
+    const { caption, mediaUrl, scheduledAt, timezone } = req.body || {};
+
+    if (!caption || typeof caption !== 'string' || !caption.trim()) {
+        return res.status(400).json({ success: false, message: 'Caption is required' });
+    }
+
+    if (!scheduledAt) {
+        return res.status(400).json({ success: false, message: 'scheduledAt is required' });
+    }
+
+    // scheduledAt is expected as an ISO string; the client is responsible for
+    // converting the creator's local picker time to an ISO/UTC timestamp
+    // before sending it (e.g. `new Date(localValue).toISOString()`), so the
+    // server only ever stores and compares UTC instants.
+    const scheduledDate = new Date(scheduledAt);
+    if (Number.isNaN(scheduledDate.getTime())) {
+        return res.status(400).json({ success: false, message: 'scheduledAt must be a valid date' });
+    }
+
+    if (scheduledDate.getTime() <= Date.now()) {
+        return res.status(400).json({ success: false, message: 'scheduledAt must be in the future' });
+    }
+
+    const content = await ScheduledContent.create({
+        userId: req.user.id,
+        caption: caption.trim(),
+        mediaUrl: mediaUrl || undefined,
+        timezone: timezone || 'UTC',
+        scheduledAt: scheduledDate,
+        status: 'scheduled',
+    });
+
+    return res.status(201).json({ success: true, content });
+});
+
+/**
+ * @function listScheduledContent
+ * @description Lists the signed-in creator's scheduled and published content, newest first.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+const listScheduledContent = asyncHandler(async (req, res) => {
+    const items = await ScheduledContent.find({ userId: req.user.id })
+        .sort({ scheduledAt: -1 })
+        .lean();
+
+    return res.json({ success: true, items });
+});
+
+/**
+ * @function cancelScheduledContent
+ * @description Cancels a piece of content that hasn't published yet.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+const cancelScheduledContent = asyncHandler(async (req, res) => {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ success: false, message: 'Invalid content id' });
+    }
+
+    const content = await ScheduledContent.findOne({ _id: req.params.id, userId: req.user.id });
+
+    if (!content) {
+        return res.status(404).json({ success: false, message: 'Scheduled content not found' });
+    }
+
+    if (content.status !== 'scheduled') {
+        return res.status(400).json({ success: false, message: `Cannot cancel content with status "${content.status}"` });
+    }
+
+    content.status = 'cancelled';
+    await content.save();
+
+    return res.json({ success: true, content });
+});
+
+module.exports = { scheduleContent, listScheduledContent, cancelScheduledContent };

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const { acceptInvite, acceptInviteFromDashboard } = require('./controller/collab
 
 connectDB();
 require("./workers/analyticsRefreshWorker");
+require("./workers/contentPublishWorker").startContentPublishWorker();
 const { generateCsrf, verifyCsrf } = require('./middleware/csrf');
 
 app.use(cookieParser());
@@ -121,6 +122,9 @@ app.use('/api/instagram', protect, instagramRoutes);
 
 const settingsRoutes = require('./routes/settings');
 app.use('/api/settings', protect, settingsRoutes);
+
+const contentRoutes = require('./routes/content');
+app.use('/api/content', protect, contentRoutes);
 
 const uploadDir = "/tmp";
 

--- a/model/scheduledContent.js
+++ b/model/scheduledContent.js
@@ -1,0 +1,51 @@
+const mongoose = require("mongoose");
+
+/**
+ * @schema scheduledContentSchema
+ * @description Content a creator has written ahead of time and scheduled to
+ * auto-publish at a future date/time. scheduledAt is always stored in UTC -
+ * the timezone field is kept only so the UI can redisplay the originally
+ * chosen local time; the publish worker always compares against UTC "now",
+ * so DST transitions in the creator's timezone can't cause an off-by-one-
+ * hour publish.
+ */
+const scheduledContentSchema = new mongoose.Schema(
+    {
+        userId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+        },
+        caption: {
+            type: String,
+            required: true,
+            trim: true,
+        },
+        mediaUrl: {
+            type: String,
+        },
+        timezone: {
+            type: String,
+            required: true,
+        },
+        scheduledAt: {
+            type: Date,
+            required: true,
+        },
+        status: {
+            type: String,
+            enum: ["scheduled", "published", "cancelled"],
+            default: "scheduled",
+        },
+        publishedAt: {
+            type: Date,
+        },
+    },
+    { timestamps: true }
+);
+
+scheduledContentSchema.index({ status: 1, scheduledAt: 1 });
+
+const ScheduledContentModel =
+    mongoose.models.ScheduledContent || mongoose.model("ScheduledContent", scheduledContentSchema);
+module.exports = ScheduledContentModel;

--- a/routes/content.js
+++ b/routes/content.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const router = express.Router();
+const {
+    scheduleContent,
+    listScheduledContent,
+    cancelScheduledContent,
+} = require('../controller/contentController');
+
+/**
+ * @swagger
+ * /schedule:
+ *   post:
+ *     summary: Schedule content for future publishing
+ *     description: Creates a piece of content scheduled to auto-publish at a future UTC time.
+ *     responses:
+ *       201:
+ *         description: Content scheduled successfully
+ *       400:
+ *         description: Bad request
+ *       401:
+ *         description: Unauthorized
+ */
+router.post('/schedule', scheduleContent);
+
+/**
+ * @swagger
+ * /scheduled:
+ *   get:
+ *     summary: List the signed-in creator's scheduled content
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *       401:
+ *         description: Unauthorized
+ */
+router.get('/scheduled', listScheduledContent);
+
+/**
+ * @swagger
+ * /scheduled/{id}:
+ *   delete:
+ *     summary: Cancel a piece of scheduled content
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *       400:
+ *         description: Bad request
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Not found
+ */
+router.delete('/scheduled/:id', cancelScheduledContent);
+
+module.exports = router;

--- a/tests/contentPublishWorker.test.js
+++ b/tests/contentPublishWorker.test.js
@@ -1,0 +1,65 @@
+const mongoose = require('mongoose');
+const { publishDueContent } = require('../workers/contentPublishWorker');
+const ScheduledContent = require('../model/scheduledContent');
+
+describe('Content Publish Worker', () => {
+    it('publishes content whose scheduledAt has passed and updates status/publishedAt', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const dueItem = await ScheduledContent.create({
+            userId,
+            caption: 'Due for publishing',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 60 * 1000), // 1 minute in the past
+            status: 'scheduled',
+        });
+
+        const publishedCount = await publishDueContent();
+        expect(publishedCount).toBe(1);
+
+        const refreshed = await ScheduledContent.findById(dueItem._id);
+        expect(refreshed.status).toBe('published');
+        expect(refreshed.publishedAt).toBeInstanceOf(Date);
+    });
+
+    it('does not publish content scheduled in the future', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const futureItem = await ScheduledContent.create({
+            userId,
+            caption: 'Not due yet',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour from now
+            status: 'scheduled',
+        });
+
+        await publishDueContent();
+
+        const refreshed = await ScheduledContent.findById(futureItem._id);
+        expect(refreshed.status).toBe('scheduled');
+        expect(refreshed.publishedAt).toBeUndefined();
+    });
+
+    it('does not re-publish content that is already published or cancelled', async () => {
+        const userId = new mongoose.Types.ObjectId();
+        const alreadyPublished = await ScheduledContent.create({
+            userId,
+            caption: 'Already published',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 60 * 1000),
+            status: 'published',
+            publishedAt: new Date(Date.now() - 30 * 1000),
+        });
+        const cancelled = await ScheduledContent.create({
+            userId,
+            caption: 'Cancelled',
+            timezone: 'UTC',
+            scheduledAt: new Date(Date.now() - 60 * 1000),
+            status: 'cancelled',
+        });
+
+        const publishedCount = await publishDueContent();
+        expect(publishedCount).toBe(0);
+
+        expect((await ScheduledContent.findById(alreadyPublished._id)).status).toBe('published');
+        expect((await ScheduledContent.findById(cancelled._id)).status).toBe('cancelled');
+    });
+});

--- a/workers/contentPublishWorker.js
+++ b/workers/contentPublishWorker.js
@@ -1,0 +1,50 @@
+const cron = require('node-cron');
+const ScheduledContent = require('../model/scheduledContent');
+
+// Runs every minute and publishes any content whose scheduledAt (stored in
+// UTC) has passed. Comparing against `new Date()` (also UTC internally)
+// means DST changes in the creator's local timezone can't cause an
+// off-by-one-hour publish - the timezone field on the document is display
+// metadata only, never used for the due-date comparison.
+//
+// NOTE: this only flips status to "published". There's no subscriber/
+// notification system in this codebase yet (no subscriber model, no email
+// dispatch for content updates), so the "notify subscribers" step from the
+// issue's proposed solution isn't included - wiring it in would mean
+// inventing a whole notification feature that's out of scope here.
+async function publishDueContent() {
+    const now = new Date();
+
+    const dueContent = await ScheduledContent.find({
+        status: 'scheduled',
+        scheduledAt: { $lte: now },
+    });
+
+    for (const item of dueContent) {
+        item.status = 'published';
+        item.publishedAt = now;
+        await item.save();
+    }
+
+    return dueContent.length;
+}
+
+function startContentPublishWorker() {
+    // Skip scheduling under the Jest test env - node-cron's timer is a live
+    // handle that never resolves, which otherwise leaves the test process
+    // hanging and forces Jest to kill it ungracefully.
+    if (process.env.NODE_ENV === 'test') return;
+
+    cron.schedule('* * * * *', async () => {
+        try {
+            const publishedCount = await publishDueContent();
+            if (publishedCount > 0) {
+                console.log(`[ContentPublishWorker] Published ${publishedCount} scheduled item(s).`);
+            }
+        } catch (error) {
+            console.error('[ContentPublishWorker] Failed to publish due content:', error.message);
+        }
+    });
+}
+
+module.exports = { startContentPublishWorker, publishDueContent };


### PR DESCRIPTION
## Summary

Creators had no way to write content ahead of time and schedule it for a future date/time — everything had to be published manually in real time. This adds a scheduling API and a background publish worker.

## Related Issue

Closes #345

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Changes Made

- **`model/scheduledContent.js`** (new): `ScheduledContent` model with `userId`, `caption`, `mediaUrl`, `timezone`, `scheduledAt`, `status` (`scheduled`/`published`/`cancelled`), `publishedAt`. `scheduledAt` is always stored and compared in UTC — `timezone` is kept only as display metadata for the UI to redisplay the originally chosen local time, so a DST transition in the creator's timezone can't cause an off-by-one-hour publish (the edge case called out in the issue).
- **`controller/contentController.js`** + **`routes/content.js`** (new), mounted at `/api/content` behind the existing `protect` auth middleware:
  - `POST /schedule` — validates `caption` is non-empty, `scheduledAt` parses to a valid date, and it's in the future, then creates the record.
  - `GET /scheduled` — lists the signed-in creator's own scheduled/published/cancelled content, newest first.
  - `DELETE /scheduled/:id` — cancels a not-yet-published item (validates the ObjectId format, and that the item belongs to the requesting user and is still in `scheduled` status).
- **`workers/contentPublishWorker.js`** (new): a `node-cron` job (already a project dependency — used the same way in `workers/analyticsRefreshWorker.js`) running every minute, publishing any `scheduled` item whose `scheduledAt` has passed by flipping it to `published` and stamping `publishedAt`. Skips scheduling entirely under `NODE_ENV=test` so the cron timer doesn't leave an open handle during the Jest run (confirmed this was actually causing a "worker process failed to exit gracefully" warning before I added the guard).
- **`tests/contentPublishWorker.test.js`** (new): covers publishing due content, leaving future-scheduled content untouched, and not re-publishing items that are already `published` or `cancelled`.
- **`index.js`**: wires up the new route and starts the worker, following the same `require(...)` pattern already used for the analytics worker.

## Scope Note

The issue's proposed solution also mentions (a) notifying subscribers on publish and (b) a content-calendar UI view with a timezone picker. I didn't implement either:

- There's no subscriber/notification system anywhere in this codebase (no subscriber model, no email/push dispatch for content updates) to wire a `notifySubscribers()` call into — building one would mean inventing a whole separate feature.
- The calendar UI is a substantial frontend surface (timezone picker, calendar view, "Schedule for later" form control) that I can't visually verify without a running browser session in my environment, so I focused on a solid, tested backend implementation rather than shipping unverified UI.

Happy to follow up on either if there's an existing path I'm missing, or if the maintainer wants the UI scoped as a separate issue.

## Testing

- [x] `npm run build` (repo's `node --check` syntax validation) passes
- [x] `node -c` on all new/changed files — no syntax errors
- [x] New test suite (`tests/contentPublishWorker.test.js`) — 3/3 passing
- [x] Ran the full Jest suite before and after — same 1 pre-existing failure in `tests/controllers/url.test.js` both times (confirmed present on `main`), no new failures, no new open-handle warnings

## Additional Notes

@aashutoshkumarbhardwaj could you review this and add the appropriate label if it looks good? Thanks!