### PR TITLE
feat: add /about and /changelog pages with working routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,6 +279,14 @@ app.get('/services', (req, res) => {
     res.redirect('/');
 });
 
+app.get('/about', (req, res) => {
+    res.render('about');
+});
+
+app.get('/changelog', (req, res) => {
+    res.render('changelog');
+});
+
 // Dashboard
 app.get("/dashboard", protect, asyncHandler(async (req, res) => {
     const userDoc = isGuestContributor(req.user)

--- a/view/about.ejs
+++ b/view/about.ejs
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About - CreatorOS</title>
+    <%- include('./partials/_brand_head') %>
+    <link rel="stylesheet" href="/css/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: 'Inter', sans-serif;
+            background: var(--bg, #F5F1EA);
+            color: var(--text, #111111);
+            padding: 2rem 1rem 4rem;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+        }
+
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.85rem;
+            font-weight: 700;
+            color: #111111;
+            text-decoration: none;
+            margin-bottom: 2rem;
+            border: 2px solid #111111;
+            padding: 0.4rem 0.85rem;
+            background: #FFFFFF;
+            box-shadow: 2px 2px 0px #111111;
+            font-family: 'Space Grotesk', sans-serif;
+        }
+
+        .back-link:hover { background: #37D6C8; }
+
+        .badge-retro {
+            display: inline-block;
+            border: 2px solid #111111;
+            font-size: 0.7rem;
+            font-family: monospace;
+            font-weight: 700;
+            padding: 0.2rem 0.5rem;
+            background-color: #37D6C8;
+            color: #111111;
+            box-shadow: 2px 2px 0px #111111;
+            margin-bottom: 1rem;
+        }
+
+        h1 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 2.8rem;
+            font-weight: 700;
+            margin: 0 0 0.5rem;
+            letter-spacing: -0.02em;
+        }
+
+        .subtitle {
+            font-size: 0.95rem;
+            color: #374151;
+            margin: 0 0 2.5rem;
+            max-width: 600px;
+            line-height: 1.6;
+        }
+
+        .cards-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1.25rem;
+            margin-bottom: 1.25rem;
+        }
+
+        .card {
+            background: #FFFFFF;
+            border: 2px solid #111111;
+            padding: 1.5rem;
+            box-shadow: 3px 3px 0px #111111;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .card:hover {
+            transform: translate(-1px, -1px);
+            box-shadow: 4px 4px 0px #111111;
+        }
+
+        .feature-chip {
+            border: 2px solid #111111;
+            padding: 0.75rem 1rem;
+            font-size: 0.8rem;
+            font-weight: 700;
+            font-family: 'Space Grotesk', sans-serif;
+            background: #F5F1EA;
+            box-shadow: 2px 2px 0px #111111;
+            text-align: center;
+            transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+            cursor: pointer;
+        }
+
+        .feature-chip:hover {
+            transform: translate(-2px, -2px);
+            box-shadow: 4px 4px 0px #111111;
+            background: #37D6C8;
+        }
+
+        .stack-chip {
+            border: 2px solid #111111;
+            padding: 0.6rem 0.85rem;
+            font-size: 0.75rem;
+            font-weight: 700;
+            font-family: monospace;
+            background: #FFFFFF;
+            box-shadow: 2px 2px 0px #111111;
+            text-align: center;
+            transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+            cursor: pointer;
+        }
+
+        .stack-chip:hover {
+            transform: translate(-2px, -2px);
+            box-shadow: 4px 4px 0px #111111;
+            background: #37D6C8;
+        }
+
+        
+        .card.accent-teal {
+            background: linear-gradient(135deg, #37D6C8 0%, #5ee8dc 50%, #37D6C8 100%);
+        }
+        .card.full-width { grid-column: 1 / -1; }
+
+        .card-label {
+            font-size: 0.7rem;
+            font-family: monospace;
+            font-weight: 700;
+            color: #6b7280;
+            letter-spacing: 0.1em;
+        }
+
+        
+        .card.accent-teal .card-label { color: #333333; }
+        .card h2 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.1rem;
+            font-weight: 700;
+            margin: 0;
+            border-left: 4px solid #37D6C8;
+            padding-left: 0.65rem;
+        }
+
+        
+        .card.accent-teal h2 { border-left-color: #111111; }
+
+        .card p {
+            font-size: 0.875rem;
+            color: #374151;
+            line-height: 1.75;
+            margin: 0;
+        }
+
+        
+        .card.accent-teal p { color: #111111; }
+        .card.accent-teal li { color: #111111; }
+
+        .card ul {
+            padding-left: 1.1rem;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .card li {
+            font-size: 0.875rem;
+            color: #374151;
+            line-height: 1.65;
+        }
+
+        .card.accent-gradient {
+            background: linear-gradient(135deg, #f0d060 0%, #E4C13B 50%, #f0d060 100%);
+        }
+
+        .card.accent-gradient .card-label,
+        .card.accent-gradient h2 ~ *,
+        .card.accent-gradient p { color: #111111; }
+        .card.accent-gradient h2 { border-left-color: #111111; }
+
+        .features-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .feature-chip {
+            border: 2px solid #111111;
+            padding: 0.75rem 1rem;
+            font-size: 0.8rem;
+            font-weight: 700;
+            font-family: 'Space Grotesk', sans-serif;
+            background: #F5F1EA;
+            box-shadow: 2px 2px 0px #111111;
+            text-align: center;
+        }
+
+        .stack-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .stack-chip {
+            border: 2px solid #111111;
+            padding: 0.6rem 0.85rem;
+            font-size: 0.75rem;
+            font-weight: 700;
+            font-family: monospace;
+            background: #FFFFFF;
+            box-shadow: 2px 2px 0px #111111;
+            text-align: center;
+        }
+
+        .cta-row {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+        }
+
+        .cta-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            border: 2px solid #111111;
+            padding: 0.65rem 1.25rem;
+            font-size: 0.85rem;
+            font-weight: 700;
+            font-family: 'Space Grotesk', sans-serif;
+            text-decoration: none;
+            color: #111111;
+            box-shadow: 2px 2px 0px #111111;
+            background: #FFFFFF;
+            transition: transform 0.15s, box-shadow 0.15s;
+        }
+
+        .cta-btn:hover {
+            transform: translate(-2px, -2px);
+            box-shadow: 4px 4px 0px #111111;
+        }
+
+        .cta-btn.primary { background: #37D6C8; }
+
+        .footer-note {
+            margin-top: 2.5rem;
+            text-align: center;
+            font-size: 0.8rem;
+            color: #6b7280;
+            border-top: 2px solid #111111;
+            padding-top: 1.5rem;
+        }
+
+        @media (max-width: 700px) {
+            .cards-grid { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="/" class="back-link">← Back to Home</a>
+
+        <span class="badge-retro">ABOUT</span>
+        <h1>About CreatorOS</h1>
+        <p class="subtitle">The all-in-one operating system for creators - stop juggling 10 tools and start owning your creator empire from one dashboard.</p>
+
+        <div class="cards-grid">
+
+            <div class="card accent-gradient full-width">
+                <span class="card-label">MISSION</span>
+                <h2>What We're Building</h2>
+                <p>CreatorOS replaces the chaos of managing Linktree, ManyChat, Notion, Buffer, and native dashboards separately. One platform. Everything connected. Zero context-switching. Built for creators who are serious about growing their audience and monetizing their knowledge.</p>
+            </div>
+
+            <div class="card">
+                <span class="card-label">FEATURES</span>
+                <h2>What CreatorOS Does</h2>
+                <div class="features-grid">
+                    <div class="feature-chip">🔗 Smart Bio Links</div>
+                    <div class="feature-chip">🤖 DM Automation</div>
+                    <div class="feature-chip">🤝 Creator CRM</div>
+                    <div class="feature-chip">📊 Analytics</div>
+                    <div class="feature-chip">🧠 Content OS</div>
+                    <div class="feature-chip">✂️ URL Shortener</div>
+                </div>
+            </div>
+
+            <div class="card">
+                <span class="card-label">WHO IT'S FOR</span>
+                <h2>Built For Creators</h2>
+                <ul>
+                    <li>📸 Instagram Influencers</li>
+                    <li>🎬 YouTubers & Video Creators</li>
+                    <li>🎓 Coaches & Solopreneurs</li>
+                    <li>📦 Digital Product Sellers</li>
+                    <li>✍️ Indie Creators & Writers</li>
+                    <li>🏷️ Brand Deal Hunters</li>
+                </ul>
+            </div>
+
+            <div class="card">
+                <span class="card-label">TECH STACK</span>
+                <h2>How It's Built</h2>
+                <div class="stack-grid">
+                    <div class="stack-chip">Node.js</div>
+                    <div class="stack-chip">Express</div>
+                    <div class="stack-chip">MongoDB</div>
+                    <div class="stack-chip">EJS</div>
+                    <div class="stack-chip">Passport</div>
+                    <div class="stack-chip">BullMQ</div>
+                    <div class="stack-chip">OpenAI</div>
+                    <div class="stack-chip">Railway</div>
+                </div>
+            </div>
+
+            <div class="card">
+                <span class="card-label">ROADMAP</span>
+                <h2>What's Coming</h2>
+                <ul>
+                    <li>✅ Smart Bio System v1</li>
+                    <li>✅ Analytics Dashboard v1</li>
+                    <li>✅ DM Automation</li>
+                    <li>✅ Creator CRM v1</li>
+                    <li>✅ Content OS + AI suggestions</li>
+                    <li>⏳ Payments & subscriptions (Stripe)</li>
+                    <li>⏳ Mobile app (React Native)</li>
+                    <li>⏳ Multi-platform support (YouTube, TikTok)</li>
+                    <li>⏳ Public API for integrations</li>
+                </ul>
+            </div>
+
+            <div class="card accent-teal full-width">
+                <span class="card-label">OPEN SOURCE</span>
+                <h2>Part of GSSoC 2026</h2>
+                <p>CreatorOS is proudly open source and part of GirlScript Summer of Code 2026. Every contribution, no matter how small, helps us build something amazing for creators worldwide. Join our community and help shape the future of creator tools.</p>
+                <div class="cta-row">
+                    <a href="https://github.com/aashutoshkumarbhardwaj/CreatorOs" target="_blank" class="cta-btn">⭐ Star on GitHub</a>
+                    <a href="https://github.com/aashutoshkumarbhardwaj/CreatorOs/issues" target="_blank" class="cta-btn">🐛 Report a Bug</a>
+                    <a href="https://github.com/aashutoshkumarbhardwaj/CreatorOs/issues" target="_blank" class="cta-btn">💡 Request Feature</a>
+                </div>
+            </div>
+
+        </div>
+
+        <p class="footer-note">© 2026 CreatorOS. Built with 🖤 for creators, by creators.</p>
+    </div>
+</body>
+</html>

--- a/view/changelog.ejs
+++ b/view/changelog.ejs
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Changelog - CreatorOS</title>
+    <%- include('./partials/_brand_head') %>
+    <link rel="stylesheet" href="/css/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: 'Inter', sans-serif;
+            background: var(--bg, #F5F1EA);
+            color: var(--text, #111111);
+            padding: 2rem 1rem 4rem;
+        }
+
+        .container {
+            max-width: 860px;
+            margin: 0 auto;
+        }
+
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.85rem;
+            font-weight: 700;
+            color: #111111;
+            text-decoration: none;
+            margin-bottom: 2rem;
+            border: 2px solid #111111;
+            padding: 0.4rem 0.85rem;
+            background: #FFFFFF;
+            box-shadow: 2px 2px 0px #111111;
+            font-family: 'Space Grotesk', sans-serif;
+        }
+
+        .back-link:hover { background: #37D6C8; }
+
+        .badge-retro {
+            display: inline-block;
+            border: 2px solid #111111;
+            font-size: 0.7rem;
+            font-family: monospace;
+            font-weight: 700;
+            padding: 0.2rem 0.5rem;
+            background-color: #37D6C8;
+            color: #111111;
+            box-shadow: 2px 2px 0px #111111;
+            margin-bottom: 1rem;
+        }
+
+        h1 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 2.8rem;
+            font-weight: 700;
+            margin: 0 0 0.5rem;
+            letter-spacing: -0.02em;
+        }
+
+        .subtitle {
+            font-size: 0.95rem;
+            color: #374151;
+            margin: 0 0 2.5rem;
+            line-height: 1.6;
+        }
+
+        .timeline {
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+
+        .release-card {
+            background: #FFFFFF;
+            border: 2px solid #111111;
+            padding: 1.5rem;
+            box-shadow: 3px 3px 0px #111111;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .release-card:hover {
+            transform: translate(-1px, -1px);
+            box-shadow: 4px 4px 0px #111111;
+        }
+
+        .release-card.latest {
+            background: linear-gradient(135deg, #37D6C8 0%, #5ee8dc 50%, #37D6C8 100%);
+        }
+
+        .release-card.latest .release-notes li,
+        .release-card.latest .release-meta { color: #111111; }
+        .accent-gradient-teal {
+            background: linear-gradient(135deg, #37D6C8 0%, #a5f5ea 50%, #37D6C8 100%) !important;
+        }
+
+        .release-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .version-badge {
+            display: inline-block;
+            border: 2px solid #111111;
+            font-size: 0.75rem;
+            font-family: monospace;
+            font-weight: 700;
+            padding: 0.2rem 0.6rem;
+            background: #111111;
+            color: #F5F1EA;
+            box-shadow: 2px 2px 0px #374151;
+        }
+
+        .release-card.latest .version-badge {
+            background: #111111;
+            color: #37D6C8;
+        }
+
+        .release-date {
+            font-size: 0.75rem;
+            font-family: monospace;
+            color: #6b7280;
+            font-weight: 600;
+        }
+
+        .release-card.latest .release-date { color: #333333; }
+
+        .release-title {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.15rem;
+            font-weight: 700;
+            margin: 0;
+            border-left: 4px solid #37D6C8;
+            padding-left: 0.65rem;
+        }
+
+        .release-card.latest .release-title {
+            border-left-color: #111111;
+        }
+
+        .release-notes {
+            padding-left: 1.1rem;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .release-notes li {
+            font-size: 0.875rem;
+            color: #374151;
+            line-height: 1.65;
+        }
+
+        .release-meta {
+            font-size: 0.75rem;
+            color: #6b7280;
+            font-family: monospace;
+        }
+
+        .tag {
+            display: inline-block;
+            border: 1.5px solid #111111;
+            font-size: 0.65rem;
+            font-family: monospace;
+            font-weight: 700;
+            padding: 0.15rem 0.4rem;
+            margin-right: 0.3rem;
+        }
+
+        .tag.feature { background: #37D6C8; }
+        .tag.fix { background: #E4C13B; }
+        .tag.improvement { background: #d1fae5; }
+
+        .footer-note {
+            margin-top: 2.5rem;
+            text-align: center;
+            font-size: 0.8rem;
+            color: #6b7280;
+            border-top: 2px solid #111111;
+            padding-top: 1.5rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="/" class="back-link">← Back to Home</a>
+
+        <span class="badge-retro">CHANGELOG</span>
+        <h1>Changelog</h1>
+        <p class="subtitle">Every update, improvement, and fix - tracked and documented.</p>
+
+        <div class="timeline">
+
+            <div class="release-card latest accent-gradient-teal">
+                <div class="release-header">
+                    <span class="version-badge">IN PROGRESS</span>
+                    <span class="release-date">JUNE – JULY 2026</span>
+                </div>
+                <h2 class="release-title">GSSoC 2026 Contributions</h2>
+                <ul class="release-notes">
+                    <li><span class="tag feature">FEATURE</span> Creator CRM with contact management</li>
+                    <li><span class="tag feature">FEATURE</span> AI-powered content suggestions via OpenAI</li>
+                    <li><span class="tag feature">FEATURE</span> DM Automation system with sequence builder</li>
+                    <li><span class="tag feature">FEATURE</span> Analytics dashboard with detailed metrics</li>
+                    <li><span class="tag improvement">IMPROVEMENT</span> Redesigned dashboard with retro neo-brutalist UI</li>
+                    <li><span class="tag improvement">IMPROVEMENT</span> Dark mode support across all pages</li>
+                    <li><span class="tag fix">FIX</span> Replaced dead footer placeholder links with valid routes</li>
+                    <li><span class="tag fix">FIX</span> Security patches and rate limiting improvements</li>
+                    <li><span class="tag fix">FIX</span> Various UI/UX bug fixes across multiple pages</li>
+                </ul>
+                <span class="release-meta">🚀 Ongoing - GSSoC 2026 open source contributions</span>
+            </div>
+
+            <div class="release-card">
+                <div class="release-header">
+                    <span class="version-badge">VERSION-1</span>
+                    <span class="release-date">MAY 26, 2026</span>
+                </div>
+                <h2 class="release-title">Initial Public Release</h2>
+                <ul class="release-notes">
+                    <li><span class="tag feature">FEATURE</span> Landing page with services hub navigation</li>
+                    <li><span class="tag feature">FEATURE</span> JWT authentication system with login & signup</li>
+                    <li><span class="tag feature">FEATURE</span> Caption, hashtag and song suggestion feature</li>
+                    <li><span class="tag feature">FEATURE</span> Collaboration invite dashboard flow</li>
+                    <li><span class="tag feature">FEATURE</span> Gaming and finance backend data arrays</li>
+                    <li><span class="tag feature">FEATURE</span> Footer added across all pages</li>
+                    <li><span class="tag fix">FIX</span> File drag and drop not working in Firefox</li>
+                    <li><span class="tag fix">FIX</span> Auth validation and error handling standardized</li>
+                    <li><span class="tag fix">FIX</span> Prevent orphaned invites on email failure</li>
+                    <li><span class="tag fix">FIX</span> Resource exhaustion and rate limiting patch</li>
+                    <li><span class="tag improvement">IMPROVEMENT</span> Standardized CreatorOS naming across all docs</li>
+                    <li><span class="tag improvement">IMPROVEMENT</span> Local dev environment and env variable config</li>
+                    <li><span class="tag improvement">IMPROVEMENT</span> UI/UX improvements across dashboard</li>
+                    <li><span class="tag improvement">IMPROVEMENT</span> Dynamic contributors showcase added to README</li>
+                </ul>
+                <span class="release-meta">🎉 First public release - 11 contributors - <a href="https://github.com/aashutoshkumarbhardwaj/CreatorOs/releases/tag/version-1" target="_blank" style="color: #37D6C8; font-weight: 700;">View on GitHub</a></span>
+            </div>
+        </div>
+
+    </div>
+
+        <p class="footer-note">© 2026 CreatorOS. All rights reserved.</p>
+    </div>
+</body>
+</html>

--- a/view/services-hub.ejs
+++ b/view/services-hub.ejs
@@ -3149,9 +3149,9 @@ footer span { color: var(--cyan); }
 
       <p class="footer-col-label">Company</p>
 
-      <a href="/#about" class="footer-link">→ About</a>
+      <a href="/about" class="footer-link">→ About</a>
 
-      <a href="/#changelog" class="footer-link">→ Changelog</a>
+      <a href="/changelog" class="footer-link">→ Changelog</a>
 
       <a href="https://discord.com" class="footer-link">→ Community</a>
 


### PR DESCRIPTION
## 📝 Description

Adds two new publicly accessible pages to CreatorOS:
- '/about' showcases what CreatorOS is, its features, target audience, tech stack and roadmap in a multi-card grid layout.
- '/changelog' documents the project's release history with real data from the official version-1 GitHub release and ongoing GSSoC 2026 contributions.

Both pages follow the existing retro neo-brutalist design system with consistent typography, colors, borders, and hover effects.

## 🔗 Related Issues

Fixes #354 

## 📋 Type of Change
<!-- Mark the type of change this PR represents -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made

- Added '/about' route in 'index.js'
- Added '/changelog' route in 'index.js'
- Created 'view/about.ejs' with mission, features, target audience, tech stack, roadmap and open source sections
- Created 'view/changelog.ejs' with real release data from version-1 and ongoing GSSoC 2026 contributions
- Both pages are publicly accessible without authentication
- Both pages include a Back to Home navigation link

## ✅ Testing

### How to Test

1. Run 'npm run dev'
2. Navigate to 'http://localhost:3000/about', verify page loads with all sections
3. Navigate to 'http://localhost:3000/changelog', verify release cards display correctly
4. Click Back to Home on both pages, verify navigation works
5. Verify both pages load without being logged in

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)

<img width="1917" height="912" alt="image" src="https://github.com/user-attachments/assets/0636d795-65d2-42c4-b081-2cd714ad0eea" />
<img width="1918" height="910" alt="image" src="https://github.com/user-attachments/assets/5667c3ba-e9c8-4da0-8584-6755714507b2" />
<img width="1918" height="903" alt="image" src="https://github.com/user-attachments/assets/c9dc1e25-1bad-4604-9caa-eb6da8f38e01" />
<img width="1918" height="902" alt="image" src="https://github.com/user-attachments/assets/6e3142b6-739e-4e4b-8fce-fb08862ee5b5" />


## 🚀 Deployment Notes

None, static EJS pages with no new dependencies.

## ⚠️ Breaking Changes
<!-- List any breaking changes -->

- None

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context

The /about and /changelog footer links were previously broken, clicking them did not navigate anywhere. Both pages are now accessible and match the existing design system. Changelog content is based on real data from the official version-1 GitHub release (May 26, 2026).

---

**Thank you for contributing to CreatorOS!** 🙌
