### PR TITLE
fix: TOCTOU race condition and missing auth/ownership checks on URL/QR endpoints

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -69,7 +69,10 @@ function serializeLink(entry, hostBase) {
  * @returns {Promise<void>|void}
  */
 async function handleGenerateShortUrl(req, res) {
-    const { redirectUrl, title, customSlug, tag } = req.body;
+    // The Zod schema accepts either `redirectUrl` or `url` as an alias;
+    // normalize here so the rest of the function only deals with one field.
+    const { redirectUrl: redirectUrlField, url, title, customSlug, tag } = req.body;
+    const redirectUrl = redirectUrlField || url;
 
     let shortId = shortid();
     if (customSlug) {
@@ -98,14 +101,27 @@ async function handleGenerateShortUrl(req, res) {
     const allowedTags = ['active', 'social', 'campaign', 'general'];
     const linkTag = allowedTags.includes(tag) ? tag : 'active';
 
-    const entry = await Url.create({
-        shortId,
-        redirectUrl,
-        userId: req.user?.id || null,
-        title: deriveTitle(redirectUrl, title?.trim()),
-        tag: linkTag,
-        linkedAt: new Date(),
-    });
+    let entry;
+    try {
+        entry = await Url.create({
+            shortId,
+            redirectUrl,
+            userId: req.user?.id || null,
+            title: deriveTitle(redirectUrl, title?.trim()),
+            tag: linkTag,
+            linkedAt: new Date(),
+        });
+    } catch (err) {
+        // TOCTOU: two concurrent requests can both pass the findOne() check
+        // above before either create() resolves. The unique index on
+        // shortId (see model/url.js) is the real guard against duplicates;
+        // this catch turns the resulting MongoDB E11000 error into a clean
+        // 409 instead of an unhandled 500.
+        if (err && err.code === 11000) {
+            return res.status(409).json({ error: 'That slug is already taken. Try another.' });
+        }
+        throw err;
+    }
 
     const hostBase = `${req.protocol}://${req.get('host')}`;
 
@@ -268,6 +284,10 @@ const handleGetQRCode = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
     }
 
+    if (entry.userId?.toString() !== req.user?.id) {
+        return res.status(403).json({ success: false, message: "Not your URL", error: "Not your URL" });
+    }
+
     const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
     const shortUrl = `${baseUrl}/u/${shortId}`;
 
@@ -301,6 +321,10 @@ const handleDownloadQRCode = asyncHandler(async (req, res) => {
         return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
     }
 
+    if (entry.userId?.toString() !== req.user?.id) {
+        return res.status(403).json({ success: false, message: "Not your URL", error: "Not your URL" });
+    }
+
     const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
     const shortUrl = `${baseUrl}/u/${shortId}`;
 
@@ -326,6 +350,16 @@ const handleUpdateQRColors = asyncHandler(async (req, res) => {
     const { shortId } = req.params;
     const { qrFgColor, qrBgColor } = req.body;
 
+    const entry = await Url.findOne({ shortId });
+
+    if (!entry) {
+        return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
+    }
+
+    if (entry.userId?.toString() !== req.user?.id) {
+        return res.status(403).json({ success: false, message: "Not your URL", error: "Not your URL" });
+    }
+
     const updated = await Url.findOneAndUpdate(
         { shortId },
         {
@@ -336,10 +370,6 @@ const handleUpdateQRColors = asyncHandler(async (req, res) => {
         },
         { new: true }
     );
-
-    if (!updated) {
-        return res.status(404).json({ success: false, message: "Short URL not found", error: "Short URL not found" });
-    }
 
     return res.json({
         success: true,

--- a/routes/url.js
+++ b/routes/url.js
@@ -105,7 +105,7 @@ router.post('/', protect, preventContributorWrites, urlShortenerApiLimiter, shor
  *       500:
  *         description: Internal server error
  */
-router.get('/qr/:shortId/download', handleDownloadQRCode);      
+router.get('/qr/:shortId/download', protect, handleDownloadQRCode);      
 
 /**
  * @swagger
@@ -123,7 +123,7 @@ router.get('/qr/:shortId/download', handleDownloadQRCode);
  *       500:
  *         description: Internal server error
  */
-router.get('/qr/:shortId',          handleGetQRCode);       
+router.get('/qr/:shortId', protect, handleGetQRCode);       
 
 /**
  * @swagger


### PR DESCRIPTION
## 📝 Description
Fixes four related issues in the URL shortener and QR code endpoints:
a TOCTOU race condition that could crash the server on concurrent
duplicate-slug requests, a field-name mismatch that could silently
create broken links, and two anonymous-access vulnerabilities on the
QR code endpoints (missing auth middleware and missing ownership
checks).

## 🔗 Related Issues
Fixes #350

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- handleGenerateShortUrl (controller/url.js): wrapped Url.create() in
  a try-catch that returns a clean 409 on MongoDB E11000 duplicate-key
  errors, closing the TOCTOU window between the findOne() existence
  check and the create() call. The unique index on shortId
  (model/url.js) is the actual guard; this just handles the resulting
  error gracefully instead of letting it crash the request.
- handleGenerateShortUrl: now reads either redirectUrl or url from the
  request body (the Zod validator already accepts both as aliases, but
  the controller only read redirectUrl), matching the pattern already
  used in handleGenerateShortUrlRender.
- routes/url.js: added protect middleware to GET /qr/:shortId and
  GET /qr/:shortId/download, which previously had zero auth and were
  fully public.
- controller/url.js: added ownership checks (403 if
  entry.userId?.toString() !== req.user?.id) to handleGetQRCode,
  handleDownloadQRCode, and handleUpdateQRColors, mirroring the check
  already present in handleGetAnalytics.
  
## ✅ Testing

### How to Test
1. TOCTOU: fire two concurrent POST /api/urls/shorten (or /shorten)
   requests with the same customSlug and confirm the loser gets a
   clean 409 instead of a 500.
2. Field normalization: POST with { "url": "https://example.com" }
   (instead of redirectUrl) and confirm the created link has the
   correct redirectUrl set.
3. QR auth: as an unauthenticated client, hit GET /api/urls/qr/:shortId
   and GET /api/urls/qr/:shortId/download for any existing shortId and
   confirm both now return 401 instead of the QR image.
4. QR ownership: as User A, try to hit
   GET /api/urls/qr/:shortId, GET /api/urls/qr/:shortId/download, and
   PATCH /api/urls/qr/:shortId/colors for a shortId owned by User B,
   and confirm each returns 403 "Not your URL".
   
### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 🚀 Deployment Notes
None — no schema/migration changes. The unique index on shortId
already existed in the schema prior to this PR.

## ⚠️ Breaking Changes
GET /qr/:shortId and GET /qr/:shortId/download now require
authentication and ownership, where they were previously fully public.
Any existing frontend or third-party usage that relied on viewing/
downloading QR codes without being logged in as the owning user will
now get 401/403 instead of the QR image. This is the intended fix per
the issue, but flagging it explicitly since it changes existing
(insecure) public behavior.

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
node --check passed on both modified files. Full Jest suite run
locally shows the identical baseline as main (3 failed suites / 4
failed tests, all pre-existing Redis/login-timeout issues unrelated to
this change — confirmed by running the suite on main directly with no
changes applied). No new test failures introduced.

No new automated tests were added for the four fixes in this PR (the
TOCTOU race in particular is hard to reliably reproduce in a unit
test without a real concurrent-request harness). Happy to add
integration tests for the QR auth/ownership checks if a maintainer
would like them before merge — those are the most straightforward to
cover (assert 401 for anonymous requests, 403 for cross-user
requests).