### PR TITLE
fix: resolve server crash on signup by validating missing fields

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -182,6 +182,14 @@ const signup = asyncHandler(async (req, res, next) => {
     const { sendVerificationEmail } = require("../utils/email");
 
     const { name, email, password } = req.body || {};
+
+    if (!name || !email || !password) {
+        if (wantsHtml(req)) {
+            return res.status(400).render("signup", { error: "Name, email, and password are required" });
+        }
+        return res.status(400).json({ success: false, message: "Name, email, and password are required" });
+    }
+
     const normalizedEmail = email.toLowerCase().trim();
 
     const existingUser = await User.findOne({ email: normalizedEmail });


### PR DESCRIPTION
This pull request addresses a critical vulnerability in the signup flow where missing fields in the request body would cause a server crash due to an unhandled TypeError. I added a strict validation block in controller/auth.js that verifies the presence of name, email, and password prior to querying the database or manipulating the data. If any of these fields are missing, the endpoint now gracefully returns a 400 Bad Request status with an appropriate error message, maintaining server stability and ensuring correct data formatting.

Closes #375 