### PR TITLE
fix: use dynamic os.tmpdir() instead of hardcoded /tmp for multer storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,10 +137,11 @@ app.use('/api/settings', protect, settingsRoutes);
 const contentRoutes = require('./routes/content');
 app.use('/api/content', protect, contentRoutes);
 
-const uploadDir = "/tmp";
+const os = require('os');
+const uploadDir = os.tmpdir();
 
 const storage = multer.diskStorage({
-    destination: function (req, file, cb) { cb(null, "/tmp"); },
+    destination: function (req, file, cb) { cb(null, uploadDir); },
     filename: function (req, file, cb) {
         let sanitizedFilename = path.basename(file.originalname);
         sanitizedFilename = sanitizedFilename.replace(/[/\\?%*:|"<>]/g, '-').replace(/^\.+/, '');


### PR DESCRIPTION
This pull request resolves a configuration bug that caused file uploads to fail in serverless deployment environments like Vercel. I imported Node.js's native os module and replaced the hardcoded "/tmp" destination string in the multer disk storage configuration with os.tmpdir(). This dynamically resolves the correct temporary directory at runtime according to the host operating system, ensuring consistent and reliable file upload behaviors across all local, containerized, and serverless deployment targets.

Closes #383 