### PR TITLE
fixed the resend login issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000 # Replace with production URL when dep
 # -------------------------------------------------------
 # Email Configuration
 
+> [!IMPORTANT]
+> Hosted deployments must configure working email delivery for verification and password reset.
+> Set `EMAIL_USER` and `EMAIL_PASSWORD`, plus either `EMAIL_SERVICE` or `EMAIL_HOST`/`EMAIL_PORT`, and keep `APP_URL` pointed at the deployed site so verification links resolve correctly.
+
 # Supported values may include:
 # smtp, gmail, resend, sendgrid, etc.
 

--- a/controller/auth.js
+++ b/controller/auth.js
@@ -14,6 +14,7 @@ const {
     clearResetAttempts,
     getRemainingResetLockoutTime,
 } = require("../utils/loginAttemptManager");
+const { isEmailTransportConfigured } = require("../utils/email");
 
 const CONTRIBUTOR_NAME = "Contributor";
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -21,6 +22,7 @@ const VERIFICATION_TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
 const GUEST_CONTRIBUTOR_ROLE = "guest_contributor";
 const GENERIC_LOGIN_ERROR = "Invalid email or password";
 const GOOGLE_AUTH_CANCELLED_ERROR = "Google sign-in was cancelled or could not be completed.";
+const VERIFICATION_UNAVAILABLE_ERROR = "Email verification is temporarily unavailable because email delivery is not configured. Please try again later or contact support.";
 
 /**
  * @function getUserModel
@@ -207,30 +209,44 @@ const signup = asyncHandler(async (req, res, next) => {
         verificationTokenExpiry,
     });
 
-    // Send verification email
-    try {
-        const baseUrl = process.env.APP_URL || `${req.protocol}://${req.get("host")}`;
-        const verificationLink = `${baseUrl}/verify-email?token=${verificationToken}`;
+    let verificationDeliveryUnavailable = false;
 
-        await sendVerificationEmail({
-            to: normalizedEmail,
-            verificationLink,
-            userName: name,
-        });
+    // Send verification email when delivery is configured.
+    try {
+        if (isEmailTransportConfigured()) {
+            const baseUrl = process.env.APP_URL || `${req.protocol}://${req.get("host")}`;
+            const verificationLink = `${baseUrl}/verify-email?token=${verificationToken}`;
+
+            await sendVerificationEmail({
+                to: normalizedEmail,
+                verificationLink,
+                userName: name,
+            });
+        } else {
+            verificationDeliveryUnavailable = true;
+        }
     } catch (emailError) {
         console.error("Failed to send verification email:", emailError);
-        // Don't fail the signup, but let user know to check email or resend
+        verificationDeliveryUnavailable = true;
+        // Don't fail the signup, but let user know verification email could not be delivered.
     }
+
+    const signupSuccessMessage = verificationDeliveryUnavailable
+        ? VERIFICATION_UNAVAILABLE_ERROR
+        : "Sign up successful! Please check your email to verify your account.";
 
     if (wantsHtml(req)) {
         return res.render("signup", { 
             error: null, 
-            success: "Sign up successful! Please check your email to verify your account." 
+            success: signupSuccessMessage,
+            verificationDeliveryUnavailable,
+            verificationEmail: normalizedEmail,
         });
     }
     return res.status(201).json({ 
         success: true, 
-        message: "Sign up successful! Please check your email to verify your account.",
+        message: signupSuccessMessage,
+        verificationDeliveryUnavailable,
         data: { id: user._id, email: user.email } 
     });
 });
@@ -239,6 +255,7 @@ const login = asyncHandler(async (req, res, next) => {
     const User = await getUserModel();
 
     const { email, password } = req.body || {};
+    const allowUnverifiedLogin = req.body?.allowUnverifiedLogin === "1" || req.body?.allowUnverifiedLogin === "true";
     const normalizedEmail = (email && typeof email === 'string') ? email.toLowerCase().trim() : "";
 
     if (!normalizedEmail || !password) {
@@ -266,6 +283,36 @@ const login = asyncHandler(async (req, res, next) => {
         await recordFailedLoginAttempt(normalizedEmail);
         if (wantsHtml(req)) return res.redirect("/login?error=" + encodeURIComponent(GENERIC_LOGIN_ERROR));
         return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
+    }
+
+    if (user.authProvider !== "google" && !user.isVerified) {
+        const verificationDeliveryUnavailable = !isEmailTransportConfigured();
+
+        if (verificationDeliveryUnavailable && allowUnverifiedLogin) {
+            await clearLoginAttempts(normalizedEmail);
+
+            user.lastLoginAt = new Date();
+            await user.save();
+
+            const token = createToken(user);
+            setAuthCookie(res, token);
+
+            if (wantsHtml(req)) return res.redirect("/dashboard?login=unverified");
+            return res.status(200).json({ success: true, token, user: serializeUser(user) });
+        }
+
+        if (wantsHtml(req)) {
+            return res.redirect(`/resend-verification?email=${encodeURIComponent(normalizedEmail)}${verificationDeliveryUnavailable ? "&delivery=unavailable" : ""}`);
+        }
+
+        return res.status(403).json({
+            success: false,
+            message: verificationDeliveryUnavailable
+                ? VERIFICATION_UNAVAILABLE_ERROR
+                : "Your account is not verified yet. Please check your email or request a new verification link.",
+            unverifiedEmail: normalizedEmail,
+            verificationDeliveryUnavailable,
+        });
     }
 
     await clearLoginAttempts(normalizedEmail);
@@ -387,7 +434,8 @@ const verifyEmail = asyncHandler(async (req, res, next) => {
                 error: "Verification link has expired. Please request a new one.",
                 success: null,
                 expiredToken: true,
-                userEmail: user.email
+                userEmail: user.email,
+                verificationDeliveryUnavailable: !isEmailTransportConfigured(),
             });
         }
         return res.status(410).json({ 
@@ -455,7 +503,9 @@ const resendVerificationEmail = asyncHandler(async (req, res, next) => {
         if (wantsHtml(req)) {
             return res.render("resend-verification", { 
                 success: "Your email is already verified. You can log in now.",
-                error: null
+                error: null,
+                prefilledEmail: normalizedEmail,
+                verificationDeliveryUnavailable: false,
             });
         }
         return res.status(200).json({ 
@@ -464,9 +514,28 @@ const resendVerificationEmail = asyncHandler(async (req, res, next) => {
         });
     }
 
+    if (!isEmailTransportConfigured()) {
+        if (wantsHtml(req)) {
+            return res.status(503).render("resend-verification", {
+                error: VERIFICATION_UNAVAILABLE_ERROR,
+                success: null,
+                prefilledEmail: normalizedEmail,
+                verificationDeliveryUnavailable: true,
+            });
+        }
+
+        return res.status(503).json({
+            success: false,
+            message: VERIFICATION_UNAVAILABLE_ERROR,
+            verificationDeliveryUnavailable: true,
+        });
+    }
+
     // Generate new verification token
     const verificationToken = generateVerificationToken();
     const verificationTokenExpiry = getVerificationTokenExpiry();
+    const previousVerificationToken = user.verificationToken;
+    const previousVerificationTokenExpiry = user.verificationTokenExpiry;
 
     user.verificationToken = verificationToken;
     user.verificationTokenExpiry = verificationTokenExpiry;
@@ -484,27 +553,36 @@ const resendVerificationEmail = asyncHandler(async (req, res, next) => {
         });
     } catch (emailError) {
         console.error("Failed to send verification email:", emailError);
+        user.verificationToken = previousVerificationToken;
+        user.verificationTokenExpiry = previousVerificationTokenExpiry;
+        await user.save();
         if (wantsHtml(req)) {
             return res.status(500).render("resend-verification", { 
-                error: "Failed to send verification email. Please try again later.",
-                success: null
+                error: VERIFICATION_UNAVAILABLE_ERROR,
+                success: null,
+                prefilledEmail: normalizedEmail,
+                verificationDeliveryUnavailable: true,
             });
         }
         return res.status(500).json({ 
             success: false, 
-            message: "Failed to send verification email. Please try again later." 
+            message: VERIFICATION_UNAVAILABLE_ERROR,
+            verificationDeliveryUnavailable: true,
         });
     }
 
     if (wantsHtml(req)) {
         return res.render("resend-verification", { 
             success: "Verification email sent! Please check your inbox.",
-            error: null
+            error: null,
+            prefilledEmail: normalizedEmail,
+            verificationDeliveryUnavailable: false,
         });
     }
     return res.status(200).json({ 
         success: true, 
-        message: "Verification email sent successfully!" 
+        message: "Verification email sent successfully!",
+        verificationDeliveryUnavailable: false,
     });
 });
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,6 +1,7 @@
 const jwt = require("jsonwebtoken");
 const connectDB = require("../connect");
 const { wantsHtml } = require("../utils/requestType");
+const { isEmailTransportConfigured } = require("../utils/email");
 
 /**
  * @function protect
@@ -50,8 +51,13 @@ const protect = async (req, res, next) => {
                 return res.redirect("/login");
             }
 
-            if (!user.isVerified && user.authProvider !== 'google') {
-                return res.status(403).redirect("/resend-verification");
+            if (!user.isVerified && user.authProvider !== 'google' && isEmailTransportConfigured()) {
+                const query = new URLSearchParams({
+                    email: decoded.email,
+                    delivery: isEmailTransportConfigured() ? 'configured' : 'unavailable',
+                });
+
+                return res.status(403).redirect(`/resend-verification?${query.toString()}`);
             }
         }
 

--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -10,6 +10,7 @@ const signupSchema = z.object({
 const loginSchema = z.object({
   email: z.string().email('Invalid email format'),
   password: z.string().min(1, 'Password is required'),
+  allowUnverifiedLogin: z.string().optional(),
 });
 
 const resendVerificationSchema = z.object({

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -118,6 +118,8 @@ router.get("/login", (req, res) => {
     res.render("login", {
         error: errorMessages[req.query.error] || req.query.error || null,
         googleAuthConfigured,
+        verificationUnavailable: req.query.verificationUnavailable === "1" || req.query.verificationUnavailable === "true",
+        unverifiedEmail: req.query.email || null,
     });
 });
 
@@ -310,7 +312,15 @@ router.post("/verify-email", emailVerificationLimiter, verifyEmail);
  *         description: Internal server error
  */
 router.get("/resend-verification", (req, res) => {
-    res.render("resend-verification", { error: null, success: null });
+    res.render("resend-verification", {
+        error: null,
+        success: null,
+        prefilledEmail: req.query.email || null,
+        verificationDeliveryUnavailable: req.query.delivery === "unavailable",
+        backToLoginUrl: req.query.delivery === "unavailable"
+            ? `/login?verificationUnavailable=1&email=${encodeURIComponent(req.query.email || "")}`
+            : "/login",
+    });
 });
 
 

--- a/tests/controllers/auth.test.js
+++ b/tests/controllers/auth.test.js
@@ -1,10 +1,32 @@
 process.env.USE_MOCK_DB = "true";
 const request = require('supertest');
+const bcrypt = require('bcryptjs');
 const app = require('../../index');
+const User = require('../../model/user');
 
 describe('Auth Controller Endpoints', () => {
     const csrfCookie = '_csrf=testtoken';
     const csrfHeader = { 'x-csrf-token': 'testtoken' };
+
+    beforeEach(async () => {
+        await User.deleteMany({});
+
+        const verifiedPassword = await bcrypt.hash('Password123!', 10);
+        await User.create({
+            name: 'Verified User',
+            email: 'test@local.com',
+            password: verifiedPassword,
+            isVerified: true,
+        });
+
+        const unverifiedPassword = await bcrypt.hash('Password123!', 10);
+        await User.create({
+            name: 'Unverified User',
+            email: 'unverified@local.com',
+            password: unverifiedPassword,
+            isVerified: false,
+        });
+    });
 
     it('should get the signup page', async () => {
         const res = await request(app).get('/signup');
@@ -29,11 +51,117 @@ describe('Auth Controller Endpoints', () => {
             .set(csrfHeader)
             .send({ email: 'test@local.com', password: 'Password123!' });
         
-        // Due to redirect on success or 200 json depending on accepts
         expect([200, 302]).toContain(res.statusCode);
         if (res.statusCode === 200) {
             expect(res.body.success).toBe(true);
         }
+    });
+
+    it('should redirect unverified users to resend verification when email verification is configured', async () => {
+        const originalEmailEnv = {
+            EMAIL_USER: process.env.EMAIL_USER,
+            EMAIL_PASSWORD: process.env.EMAIL_PASSWORD,
+            EMAIL_SERVICE: process.env.EMAIL_SERVICE,
+            EMAIL_HOST: process.env.EMAIL_HOST,
+        };
+
+        process.env.EMAIL_USER = 'tester@example.com';
+        process.env.EMAIL_PASSWORD = 'password';
+        process.env.EMAIL_SERVICE = 'smtp';
+        delete process.env.EMAIL_HOST;
+
+        try {
+            const res = await request(app)
+                .post('/login')
+                .set('Cookie', [csrfCookie])
+                .set(csrfHeader)
+                .send({ email: 'unverified@local.com', password: 'Password123!' });
+
+            expect(res.statusCode).toBe(302);
+            expect(res.headers.location).toContain('/resend-verification');
+        } finally {
+            process.env.EMAIL_USER = originalEmailEnv.EMAIL_USER;
+            process.env.EMAIL_PASSWORD = originalEmailEnv.EMAIL_PASSWORD;
+            process.env.EMAIL_SERVICE = originalEmailEnv.EMAIL_SERVICE;
+            process.env.EMAIL_HOST = originalEmailEnv.EMAIL_HOST;
+        }
+    });
+
+    it('should redirect unverified users to resend verification when email verification is not configured', async () => {
+        const originalEmailEnv = {
+            EMAIL_USER: process.env.EMAIL_USER,
+            EMAIL_PASSWORD: process.env.EMAIL_PASSWORD,
+            EMAIL_SERVICE: process.env.EMAIL_SERVICE,
+            EMAIL_HOST: process.env.EMAIL_HOST,
+        };
+
+        delete process.env.EMAIL_USER;
+        delete process.env.EMAIL_PASSWORD;
+        delete process.env.EMAIL_SERVICE;
+        delete process.env.EMAIL_HOST;
+
+        try {
+            const res = await request(app)
+                .post('/login')
+                .set('Cookie', [csrfCookie])
+                .set(csrfHeader)
+                .send({ email: 'unverified@local.com', password: 'Password123!' });
+
+            expect(res.statusCode).toBe(302);
+            expect(res.headers.location).toContain('/resend-verification');
+        } finally {
+            process.env.EMAIL_USER = originalEmailEnv.EMAIL_USER;
+            process.env.EMAIL_PASSWORD = originalEmailEnv.EMAIL_PASSWORD;
+            process.env.EMAIL_SERVICE = originalEmailEnv.EMAIL_SERVICE;
+            process.env.EMAIL_HOST = originalEmailEnv.EMAIL_HOST;
+        }
+    });
+
+    it('should allow login after returning from resend-verification when delivery is unavailable', async () => {
+        const originalEmailEnv = {
+            EMAIL_USER: process.env.EMAIL_USER,
+            EMAIL_PASSWORD: process.env.EMAIL_PASSWORD,
+            EMAIL_SERVICE: process.env.EMAIL_SERVICE,
+            EMAIL_HOST: process.env.EMAIL_HOST,
+        };
+
+        delete process.env.EMAIL_USER;
+        delete process.env.EMAIL_PASSWORD;
+        delete process.env.EMAIL_SERVICE;
+        delete process.env.EMAIL_HOST;
+
+        try {
+            const res = await request(app)
+                .post('/login')
+                .set('Cookie', [csrfCookie])
+                .set(csrfHeader)
+                .send({
+                    email: 'unverified@local.com',
+                    password: 'Password123!',
+                    allowUnverifiedLogin: '1',
+                });
+
+            expect([200, 302]).toContain(res.statusCode);
+            if (res.statusCode === 200) {
+                expect(res.body.success).toBe(true);
+            } else {
+                expect(res.headers.location).toContain('/dashboard');
+            }
+        } finally {
+            process.env.EMAIL_USER = originalEmailEnv.EMAIL_USER;
+            process.env.EMAIL_PASSWORD = originalEmailEnv.EMAIL_PASSWORD;
+            process.env.EMAIL_SERVICE = originalEmailEnv.EMAIL_SERVICE;
+            process.env.EMAIL_HOST = originalEmailEnv.EMAIL_HOST;
+        }
+    });
+
+    it('should show resend verification as unavailable when email delivery is not configured', async () => {
+        const res = await request(app)
+            .get('/resend-verification')
+            .query({ email: 'unverified@local.com', delivery: 'unavailable' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toMatch(/email verification is temporarily unavailable/i);
     });
 
     it('should get the login page', async () => {

--- a/tests/controllers/collaboration.test.js
+++ b/tests/controllers/collaboration.test.js
@@ -1,6 +1,8 @@
 process.env.USE_MOCK_DB = "true";
 const request = require('supertest');
+const bcrypt = require('bcryptjs');
 const app = require('../../index');
+const User = require('../../model/user');
 
 jest.mock('../../utils/email', () => ({
     sendInvitationEmail: jest.fn().mockResolvedValue(true)
@@ -12,6 +14,15 @@ describe('Collaboration Controller Endpoints', () => {
     let authCookie;
 
     beforeAll(async () => {
+        await User.deleteMany({});
+        const password = await bcrypt.hash('Password123!', 10);
+        await User.create({
+            name: 'Verified User',
+            email: 'test@local.com',
+            password,
+            isVerified: true,
+        });
+
         const res = await request(app)
             .post('/login')
             .set('Cookie', [csrfCookie])

--- a/tests/controllers/url.test.js
+++ b/tests/controllers/url.test.js
@@ -1,6 +1,8 @@
 process.env.USE_MOCK_DB = "true";
 const request = require('supertest');
+const bcrypt = require('bcryptjs');
 const app = require('../../index');
+const User = require('../../model/user');
 
 describe('URL Controller Endpoints', () => {
     const csrfCookie = '_csrf=testtoken';
@@ -8,6 +10,15 @@ describe('URL Controller Endpoints', () => {
     let authCookie;
 
     beforeAll(async () => {
+        await User.deleteMany({});
+        const password = await bcrypt.hash('Password123!', 10);
+        await User.create({
+            name: 'Verified User',
+            email: 'test@local.com',
+            password,
+            isVerified: true,
+        });
+
         const res = await request(app)
             .post('/login')
             .set('Cookie', [csrfCookie])

--- a/utils/email.js
+++ b/utils/email.js
@@ -51,6 +51,24 @@ function createTransporter() {
 }
 
 /**
+ * @function isEmailTransportConfigured
+ * @description Checks whether the deployment has enough mail settings to attempt delivery.
+ * @returns {boolean}
+ */
+function isEmailTransportConfigured() {
+  const currentEmailUser = process.env.EMAIL_USER;
+  const currentEmailPassword = process.env.EMAIL_PASSWORD;
+  const currentEmailService = process.env.EMAIL_SERVICE;
+  const currentEmailHost = process.env.EMAIL_HOST;
+
+  return Boolean(
+    currentEmailUser &&
+    currentEmailPassword &&
+    (currentEmailService || currentEmailHost)
+  );
+}
+
+/**
  * @function sendInvitationEmail
  * @description Sends a collaboration invitation email to a specified recipient.
  * @param {Object} req - Express request object
@@ -201,4 +219,5 @@ module.exports = {
   sendInvitationEmail,
   sendVerificationEmail,
   sendPasswordResetEmail,
+  isEmailTransportConfigured,
 };

--- a/view/login.ejs
+++ b/view/login.ejs
@@ -534,15 +534,21 @@
         <!-- Right Panel -->
         <section class="right-panel">
             <div class="form-container">
+                <% if (typeof error !== 'undefined' && error) { %>
+                    <div class="auth-error" role="alert">
+                        <%= error %>
+                    </div>
+                <% } %>
+
                 <% if (typeof unverifiedEmail !== 'undefined' && unverifiedEmail) { %>
                     <div class="auth-unverified" role="alert">
                         <h3>📧 Email Not Verified</h3>
                         <p>Please verify your email address before logging in.</p>
-                        <a href="/resend-verification?email=<%= encodeURIComponent(unverifiedEmail) %>">Resend Verification Email</a>
-                    </div>
-                <% } else if (typeof error !== 'undefined' && error) { %>
-                    <div class="auth-error" role="alert">
-                        <%= error %>
+                        <% if (typeof verificationUnavailable !== 'undefined' && verificationUnavailable) { %>
+                            <p>Email delivery is temporarily unavailable, so you can continue to log in without verification.</p>
+                        <% } else { %>
+                            <a href="/resend-verification?email=<%= encodeURIComponent(unverifiedEmail) %>">Resend Verification Email</a>
+                        <% } %>
                     </div>
                 <% } %>
 
@@ -569,6 +575,9 @@
 
                 <form action="/login" method="POST" id="email-login-form">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <% if (typeof verificationUnavailable !== 'undefined' && verificationUnavailable) { %>
+                        <input type="hidden" name="allowUnverifiedLogin" value="1">
+                    <% } %>
                     <div class="form-group">
                         <div class="label-row">
                             <label for="login-email">Email Address</label>

--- a/view/resend-verification.ejs
+++ b/view/resend-verification.ejs
@@ -218,6 +218,13 @@
             <p>Enter your email address to receive a new verification link</p>
         </div>
 
+        <% if (typeof verificationDeliveryUnavailable !== 'undefined' && verificationDeliveryUnavailable) { %>
+            <div class="alert error" role="alert">
+                Email verification is temporarily unavailable on this deployment because email delivery is not configured.
+                Please try again later or contact support.
+            </div>
+        <% } %>
+
         <% if (typeof error !== 'undefined' && error) { %>
             <div class="alert error">
                 <%= error %>
@@ -230,7 +237,10 @@
             </div>
             <div style="text-align: center; margin-top: 2rem;">
                 <p style="margin-bottom: 1rem;">Check your email for a verification link to activate your account.</p>
-                <a href="/login" class="btn btn-secondary">Back to Login</a>
+                <a href="<%= typeof backToLoginUrl !== 'undefined' && backToLoginUrl ? backToLoginUrl : '/login' %>" class="btn btn-secondary">Back to Login</a>
+                <% if (typeof verificationDeliveryUnavailable !== 'undefined' && verificationDeliveryUnavailable) { %>
+                    <a href="/dashboard" class="btn btn-secondary" style="margin-top: 0.75rem;">Go to Dashboard</a>
+                <% } %>
             </div>
         <% } else { %>
             <form method="POST" action="/resend-verification">
@@ -244,13 +254,17 @@
                         required 
                         placeholder="you@example.com"
                         autocomplete="email"
+                        value="<%= typeof prefilledEmail !== 'undefined' && prefilledEmail ? prefilledEmail : '' %>"
                     >
                     <p class="help-text">We'll send a verification link to this address.</p>
                 </div>
 
                 <div class="actions">
-                    <button type="submit">Send Verification Email</button>
-                    <a href="/login" class="btn btn-secondary">Back to Login</a>
+                    <button type="submit" <%= verificationDeliveryUnavailable ? 'disabled aria-disabled="true"' : '' %>><%= verificationDeliveryUnavailable ? 'Verification Unavailable' : 'Send Verification Email' %></button>
+                    <a href="<%= typeof backToLoginUrl !== 'undefined' && backToLoginUrl ? backToLoginUrl : '/login' %>" class="btn btn-secondary">Back to Login</a>
+                    <% if (typeof verificationDeliveryUnavailable !== 'undefined' && verificationDeliveryUnavailable) { %>
+                        <a href="/dashboard" class="btn btn-secondary">Go to Dashboard</a>
+                    <% } %>
                 </div>
             </form>
 

--- a/view/signup.ejs
+++ b/view/signup.ejs
@@ -468,8 +468,13 @@
                     <div class="auth-success" role="alert">
                         <h3>✓ Account Created!</h3>
                         <p><%= success %></p>
+                        <% if (typeof verificationDeliveryUnavailable !== 'undefined' && verificationDeliveryUnavailable) { %>
+                            <p>Email delivery is temporarily unavailable, so verification cannot be sent yet.</p>
+                        <% } %>
                         <div class="success-actions">
-                            <a href="/resend-verification">Resend Verification Email</a>
+                            <% if (typeof verificationDeliveryUnavailable === 'undefined' || !verificationDeliveryUnavailable) { %>
+                                <a href="/resend-verification?email=<%= encodeURIComponent(typeof verificationEmail !== 'undefined' ? verificationEmail : '') %>">Resend Verification Email</a>
+                            <% } %>
                             <a href="/login">Back to Login</a>
                         </div>
                     </div>

--- a/view/verify-email.ejs
+++ b/view/verify-email.ejs
@@ -205,18 +205,25 @@
             <% if (expiredToken && userEmail) { %>
                 <div class="expired-section">
                     <p>Your verification link has expired. Request a new one below:</p>
+                    <% if (typeof verificationDeliveryUnavailable !== 'undefined' && verificationDeliveryUnavailable) { %>
+                        <p>Email delivery is temporarily unavailable, so resend is disabled right now.</p>
+                    <% } %>
                 </div>
             <% } %>
 
             <div class="actions">
                 <% if (expiredToken && userEmail) { %>
-                    <form method="POST" action="/resend-verification">
-                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                        <input type="hidden" name="email" value="<%= userEmail %>">
-                        <button type="submit" class="btn btn-primary" style="width: 100%; border: none;">
-                            Resend Verification Email
-                        </button>
-                    </form>
+                    <% if (typeof verificationDeliveryUnavailable !== 'undefined' && verificationDeliveryUnavailable) { %>
+                        <a href="/resend-verification?email=<%= encodeURIComponent(userEmail) %>" class="btn btn-primary" aria-disabled="true" style="pointer-events: none; opacity: 0.6;">Resend Verification Email</a>
+                    <% } else { %>
+                        <form method="POST" action="/resend-verification">
+                            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                            <input type="hidden" name="email" value="<%= userEmail %>">
+                            <button type="submit" class="btn btn-primary" style="width: 100%; border: none;">
+                                Resend Verification Email
+                            </button>
+                        </form>
+                    <% } %>
                 <% } %>
                 <a href="/signup" class="btn btn-secondary">Back to Signup</a>
             </div>


### PR DESCRIPTION
## 📝 Description
Fixes the email verification dead-end so unverified users can still access the app when email delivery is unavailable.

## 🔗 Related Issues
Fixes #374 

## 📋 Type of Change
- [x] 🐛 Bug fix
- [x] 📚 Documentation update
- [x] 🧪 Test update

## 🔄 Changes Made
- Redirect unverified logins to resend-verification first.
- Allow login when email delivery is not configured.
- Show clearer resend/login UI states.
- Add email setup notes and regression tests.

## ✅ Testing
1. Try logging in with an unverified account.
2. Test with email config enabled and disabled.
3. Run the Jest suite.

## 🚀 Deployment Notes
Email verification requires `EMAIL_USER`, `EMAIL_PASSWORD`, and either `EMAIL_SERVICE` or `EMAIL_HOST`/`EMAIL_PORT`, plus `APP_URL`.

## ⚠️ Breaking Changes
- None
- 
<img width="1280" height="758" alt="Screenshot 2026-07-07 at 13 44 16" src="https://github.com/user-attachments/assets/88a8b576-d898-4364-98b9-39d801183cf9" />
If email service is unavailable a button to launch dashboard will appear on screen