### PR TITLE
fix: cap visitHistory array to 1000 entries via  to prevent document growth (#386)

### DIFF
--- a/index.js
+++ b/index.js
@@ -621,7 +621,13 @@ app.get('/u/:shortId', asyncHandler(async (req, res) => {
             { shortId },
             {
                 $inc:  { totalClicks: 1 },
-                $push: { visitHistory: { timestamp: new Date(), source: 'direct' } },
+                $push: {
+                    visitHistory: {
+                        $each: [{ timestamp: new Date(), source: 'direct' }],
+                        $sort: { timestamp: -1 },
+                        $slice: 1000,
+                    },
+                },
             },
             { new: true }
         );


### PR DESCRIPTION
﻿## Description

Each URL redirect pushed a new `{ timestamp, source }` entry onto `visitHistory` using a bare `$push`. Over time this array grows without bound, causing the MongoDB document to exceed the 16 MB BSON limit and eventually crash the application.

## Changes

Replaced the bare `$push` with `$each` + `$sort` + `$slice`:
```
$push: {
    visitHistory: {
        $each: [{ timestamp: new Date(), source: "direct" }],
        $sort: { timestamp: -1 },
        $slice: 1000,
    },
},
```
This caps the array at **1000 most recent entries**, keeping the newest ones and discarding the oldest.

## Related Issue

Closes #386
