### PR TITLE
fix: disable analytics refresh cron in test environment (#387)

### DIFF
--- a/workers/analyticsRefreshWorker.js
+++ b/workers/analyticsRefreshWorker.js
@@ -91,32 +91,34 @@ if (!REDIS_URI) {
         console.error(`[AnalyticsWorker] Job failed for creator: ${job?.data?.username}:`, err.message);
     });
 
-    // Runs every 6 hours
-    cron.schedule("0 */6 * * *", async () => {
-        console.log("[AnalyticsWorker] Scheduling refresh jobs...");
+    // Runs every 6 hours (disabled in test environment)
+    if (process.env.NODE_ENV !== 'test') {
+        cron.schedule("0 */6 * * *", async () => {
+            console.log("[AnalyticsWorker] Scheduling refresh jobs...");
 
-        try {
-            const creators = await Creator.find({});
+            try {
+                const creators = await Creator.find({});
 
-            for (const creator of creators) {
-                await analyticsQueue.add("refresh", {
-                    creatorId: creator._id,
-                    platform: creator.platform,
-                    username: creator.username
-                }, {
-                    attempts: 3,
-                    backoff: {
-                        type: 'exponential',
-                        delay: 5000
-                    }
-                });
+                for (const creator of creators) {
+                    await analyticsQueue.add("refresh", {
+                        creatorId: creator._id,
+                        platform: creator.platform,
+                        username: creator.username
+                    }, {
+                        attempts: 3,
+                        backoff: {
+                            type: 'exponential',
+                            delay: 5000
+                        }
+                    });
+                }
+
+                console.log(`[AnalyticsWorker] Scheduled ${creators.length} refresh jobs.`);
+            } catch (err) {
+                console.error("[AnalyticsWorker] Error scheduling refresh:", err.message);
             }
-
-            console.log(`[AnalyticsWorker] Scheduled ${creators.length} refresh jobs.`);
-        } catch (err) {
-            console.error("[AnalyticsWorker] Error scheduling refresh:", err.message);
-        }
-    });
+        });
+    }
 }
 
 module.exports = { analyticsQueue, analyticsWorker };


### PR DESCRIPTION
﻿## Description

The analytics refresh worker registers a `cron.schedule("0 */6 * * *", ...)` job at module load time that runs every 6 hours. During test execution, this cron job fires in the background and attempts to query the database, causing:

- Flaky tests due to unexpected DB writes
- Test contamination between test cases
- Slower test suites from concurrent cron activity

## Changes

Wrapped the `cron.schedule(...)` block in `if (process.env.NODE_ENV !== "test")`, preventing the periodic scheduling when running tests. The worker itself (`analyticsQueue` / `analyticsWorker`) is still available for manual job dispatch in tests.

## Related Issue

Closes #387
