### PR TITLE
fix: add Zod validation schema for profile update endpoint (#388)

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -53,6 +53,12 @@ const suggestionSchema = z.object({
   topic: z.string().min(1, 'Topic is required'),
 });
 
+const updateProfileSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name must be at most 100 characters').optional(),
+  alias: z.string().min(1, 'Alias is required').max(50, 'Alias must be at most 50 characters').regex(/^[a-zA-Z0-9_-]+$/, 'Alias can only contain letters, numbers, hyphens and underscores').optional(),
+  bio: z.string().max(500, 'Bio must be at most 500 characters').optional(),
+});
+
 const objectIdParamSchema = z.object({
   creatorId: z.string().regex(/^[a-f\d]{24}$/i, 'Invalid creatorId'),
 });
@@ -88,6 +94,7 @@ module.exports = {
     urlShortenSchema,
     urlQRColorsSchema,
     suggestionSchema,
+    updateProfileSchema,
     objectIdParamSchema,
     shortIdParamSchema,
     validate,

--- a/model/user.js
+++ b/model/user.js
@@ -51,10 +51,12 @@ const userSchema = new mongoose.Schema(
         
         alias: {
             type: String,
+            maxlength: 50,
         },
         
         bio: {
             type: String,
+            maxlength: 500,
         },
         
         twoFactorEnabled: {

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const bcrypt = require('bcryptjs');
 const User = require('../model/user');
 const { preventContributorWrites } = require('../middleware/auth');
+const { validate, updateProfileSchema } = require('../middleware/validators');
 
 const asyncHandler = fn => (req, res, next) =>
     Promise.resolve(fn(req, res, next)).catch(next);
@@ -65,7 +66,7 @@ function daysSince(date) {
  *       500:
  *         description: Internal server error
  */
-router.put('/profile', preventContributorWrites, asyncHandler(async (req, res) => {
+router.put('/profile', preventContributorWrites, validate(updateProfileSchema, 'body'), asyncHandler(async (req, res) => {
     const { name, alias, bio } = req.body;
     
     const user = await User.findById(req.user.id);


### PR DESCRIPTION
## Description

The PUT /api/settings/profile endpoint accepted name, alias, and bio fields without any server-side validation. An attacker (or even a legitimate user) could:

- Submit a name/bio of arbitrary length, bloating the database
- Inject special characters or control characters into the alias field (used in URLs)
- Bypass client-side validation entirely by sending requests directly

## Changes

- **middleware/validators.js** — Added updateProfileSchema (Zod schema) with length constraints and alias regex validation
- **routes/settings.js** — Added validate(updateProfileSchema, 'body') middleware to the PUT /profile route
- **model/user.js** — Added maxlength: 50 on alias and maxlength: 500 on bio as defense-in-depth

## Related Issue

Closes #388