### PR TITLE
Fix sidebar overlapping main content on mobile screens

### DIFF
--- a/view/partials/layout/scripts.ejs
+++ b/view/partials/layout/scripts.ejs
@@ -36,10 +36,22 @@
         // Sidebar Mobile Toggle
         const sidebarBtn = document.getElementById('sidebarToggle');
         const sidebar = document.getElementById('sidebar');
-        if(sidebarBtn) {
-            sidebarBtn.addEventListener('click', () => {
-                sidebar.classList.toggle('show');
-            });
+        const layout = document.getElementById('dashboardLayout');
+        
+        if (layout) {
+            // Hide by default on screens < 768px
+            if (window.innerWidth < 768 || localStorage.getItem('creatorosSidebarCollapsed') === 'true') {
+                layout.classList.add('sidebar-collapsed');
+                if (sidebarBtn) sidebarBtn.setAttribute('aria-expanded', 'false');
+            }
+
+            if (sidebarBtn) {
+                sidebarBtn.addEventListener('click', () => {
+                    const isCollapsed = layout.classList.toggle('sidebar-collapsed');
+                    sidebarBtn.setAttribute('aria-expanded', String(!isCollapsed));
+                    localStorage.setItem('creatorosSidebarCollapsed', String(isCollapsed));
+                });
+            }
         }
     });
 </script>


### PR DESCRIPTION
Resolves #406. Implemented a responsive hamburger menu for mobile views. Hidden the sidebar by default on screens < 768px. Ensured smooth transition animations for opening/closing the sidebar.