### PR TITLE
fix: add skip-to-content link for dashboard pages

### DIFF
--- a/view/analytics-dashboard.ejs
+++ b/view/analytics-dashboard.ejs
@@ -1428,7 +1428,7 @@
         <%- include('partials/layout/sidebar', { activeNav: 'dashboard' }) %>
 
         <!-- Main Workspace Panel -->
-        <main class="main">
+        <main class="main" id="main-content" tabindex="-1">
             <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">

--- a/view/analytics.ejs
+++ b/view/analytics.ejs
@@ -529,7 +529,7 @@
   <%- include('partials/layout/sidebar', { activeNav: 'analytics' }) %>
 
   <!-- MAIN -->
-  <div class="main">
+  <main class="main" id="main-content" tabindex="-1">
 
     <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
@@ -681,7 +681,7 @@
       </div>
 
     </section>
-  </div>
+  </main>
 </div>
 
 <script nonce="<%= nonce %>">

--- a/view/creator-crm.ejs
+++ b/view/creator-crm.ejs
@@ -1794,7 +1794,7 @@
   <%- include('partials/layout/sidebar', { activeNav: 'crm' }) %>
 
   <!-- MAIN -->
-  <div class="main">
+  <main class="main" id="main-content" tabindex="-1">
 
     <!-- TOPBAR -->
     <%- include('partials/layout/topbar', { 
@@ -1817,7 +1817,7 @@
             <button class="col-header-action">
               <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
             </button>
-          </div>
+  </main>
           <div class="col-body">
             <!-- Card 1 -->
             <div class="deal-card">

--- a/view/dashboard.ejs
+++ b/view/dashboard.ejs
@@ -1391,7 +1391,7 @@
         <%- include('partials/layout/sidebar', { activeNav: 'dashboard' }) %>
 
         <!-- Main Workspace Panel -->
-        <main class="main">
+        <main class="main" id="main-content" tabindex="-1">
             <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">

--- a/view/dm-automation.ejs
+++ b/view/dm-automation.ejs
@@ -1775,7 +1775,7 @@
     <%- include('partials/layout/sidebar', { activeNav: 'dm-automation' }) %>
 
     <!-- Main Panel -->
-    <main class="main">
+    <main class="main" id="main-content" tabindex="-1">
       
       <!-- Top Navigation -->
       <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>

--- a/view/home.ejs
+++ b/view/home.ejs
@@ -1371,7 +1371,7 @@
         <%- include('partials/layout/sidebar', { activeNav: 'home' }) %>
 
         <!-- Main Workspace Panel -->
-        <main class="main">
+        <main class="main" id="main-content" tabindex="-1">
             <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">

--- a/view/my-links.ejs
+++ b/view/my-links.ejs
@@ -1617,7 +1617,7 @@
         <%- include('partials/layout/sidebar', { activeNav: 'my-links' }) %>
 
         <!-- Main Workspace Panel -->
-        <main class="main">
+        <main class="main" id="main-content" tabindex="-1">
             <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <section class="content">
@@ -1784,5 +1784,4 @@
     <%- include('partials/layout/scripts') %>
 </body>
 </html>
-
 

--- a/view/partials/dashboard/_sidebar.ejs
+++ b/view/partials/dashboard/_sidebar.ejs
@@ -3,6 +3,7 @@
   Props (passed via locals):
     - services  {Array<{name, status, route}>}
 %>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <aside class="sidebar" aria-label="Dashboard navigation">
 
   <!-- Brand / Logo -->

--- a/view/partials/dashboard/_styles.ejs
+++ b/view/partials/dashboard/_styles.ejs
@@ -37,6 +37,28 @@
 
   a { color: inherit; }
 
+  .skip-link {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 1000;
+    padding: 0.8rem 1rem;
+    border-radius: 0.75rem;
+    color: #042f3e;
+    background: linear-gradient(135deg, var(--accent), var(--accent-2));
+    text-decoration: none;
+    font-weight: 800;
+    transform: translateY(-180%);
+    transition: transform 0.2s ease;
+    box-shadow: 0 16px 34px rgba(34,211,238,0.2);
+  }
+
+  .skip-link:focus {
+    transform: translateY(0);
+    outline: 2px solid #67e8f9;
+    outline-offset: 2px;
+  }
+
   /* ── Layout ── */
   .dashboard-layout {
     min-height: 100vh;

--- a/view/partials/dashboard/dashboard.ejs
+++ b/view/partials/dashboard/dashboard.ejs
@@ -16,7 +16,7 @@
 
     <%- include('./partials/dashboard/_sidebar', { services }) %>
 
-    <main class="main">
+    <main class="main" id="main-content" tabindex="-1">
 
       <%- include('./partials/dashboard/_topbar', { user }) %>
 

--- a/view/partials/layout/sidebar.ejs
+++ b/view/partials/layout/sidebar.ejs
@@ -1,3 +1,27 @@
+<style>
+    .skip-link {
+        position: absolute;
+        top: 1rem;
+        left: 1rem;
+        z-index: 1000;
+        padding: 0.75rem 1rem;
+        border: 2px solid var(--border, #111);
+        background: var(--card-bg, #fff);
+        color: var(--text, #111);
+        font-weight: 700;
+        text-decoration: none;
+        transform: translateY(-180%);
+        transition: transform 0.2s ease;
+        box-shadow: 2px 2px 0 var(--border, #111);
+    }
+
+    .skip-link:focus {
+        transform: translateY(0);
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+</style>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
     <a class="brand" href="/dashboard" aria-label="CreatorOS">
         <span class="brand-mark" style="background:none;border:none;box-shadow:none;">

--- a/view/settings.ejs
+++ b/view/settings.ejs
@@ -34,7 +34,7 @@
     <div class="workspace-layout settings-layout" id="dashboardLayout">
         <%- include('partials/layout/sidebar', { activeNav: 'settings' }) %>
 
-        <main class="workspace-main settings-main">
+        <main class="workspace-main settings-main" id="main-content" tabindex="-1">
             <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
             <div class="settings-content">

--- a/view/vault.ejs
+++ b/view/vault.ejs
@@ -513,7 +513,7 @@
   <%- include('partials/layout/sidebar', { activeNav: 'vault' }) %>
 
   <!-- MAIN -->
-  <div class="main">
+  <main class="main" id="main-content" tabindex="-1">
 
     <%- include('partials/layout/topbar', { user: typeof user !== 'undefined' ? user : { initials: 'U', name: 'User' } }) %>
 
@@ -623,7 +623,7 @@
       </div><!-- /files-grid -->
 
     </section>
-  </div>
+  </main>
 </div>
 
 <!-- TOAST -->


### PR DESCRIPTION
## Summary
- add a keyboard-visible skip link to the shared dashboard shells
- wire dashboard pages to a focusable `#main-content` target
- convert shared dashboard wrappers to semantic `<main>` landmarks where needed

Closes #273

## Validation
- npm run build
- git diff --check