### PR TITLE
fix: allow unauthenticated access to Instagram webhook endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ const swaggerSpec = require('./utils/swaggerOptions');
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, { customCssUrl: 'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.0.0/swagger-ui.min.css' }));
 
 app.use("/api/analytics", protect, analyticsRoutes);
-app.use('/api/instagram', protect, instagramRoutes);
+app.use('/api/instagram', instagramRoutes);
 
 const settingsRoutes = require('./routes/settings');
 app.use('/api/settings', protect, settingsRoutes);

--- a/routes/instagram.js
+++ b/routes/instagram.js
@@ -4,6 +4,7 @@ const { verifyWebhook, verifyWebhookSignature, handleWebhook } = require('../con
 
 const router = express.Router();
 
+const { protect } = require('../middleware/auth');
 const { instagramProfileLimiter } = require('../middleware/rateLimiters');
 
 /**
@@ -22,7 +23,7 @@ const { instagramProfileLimiter } = require('../middleware/rateLimiters');
  *       500:
  *         description: Internal server error
  */
-router.get('/profile', instagramProfileLimiter, getInstagramProfile);
+router.get('/profile', protect, instagramProfileLimiter, getInstagramProfile);
 
 // Instagram DM Automation Webhook Endpoints
 router.get('/webhook', verifyWebhook);


### PR DESCRIPTION
This pull request resolves the issue where external Instagram webhook endpoints were inadvertently blocked by user authentication middleware. The fix removes the global protect middleware from the /api/instagram router mount in index.js and instead explicitly applies it only to the /profile route within routes/instagram.js. This targeted approach ensures that user-facing API routes remain properly secured with JWT authentication, while allowing external Meta servers to successfully reach the /webhook endpoints. The webhooks remain secure as they are still protected by their dedicated verifyWebhookSignature middleware to validate incoming payload signatures.

Closes #436 