### PR TITLE
fix: prevent password reset token race condition (#419)

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -668,19 +668,21 @@ const resetPassword = asyncHandler(async (req, res) => {
         return res.status(400).json({ success: false, message: 'Token and password are required' });
     }
 
-    // Find reset token
-    const resetTokenDoc = await PasswordResetToken.findOne({ token });
+    // Atomically claim the token: find a valid unused token and mark it used in one operation
+    const resetTokenDoc = await PasswordResetToken.findOneAndUpdate(
+        { token, used: false, expiresAt: { $gt: new Date() } },
+        { $set: { used: true, usedAt: new Date() } },
+        { new: true }
+    );
     if (!resetTokenDoc) {
-        return res.status(400).json({ success: false, message: 'Invalid or expired reset token' });
-    }
-
-    // Check if token is already used
-    if (resetTokenDoc.used) {
-        return res.status(400).json({ success: false, message: 'This reset token has already been used' });
-    }
-
-    // Check if token has expired
-    if (resetTokenDoc.expiresAt < new Date()) {
+        // Check if token exists at all to give a more specific error
+        const existingToken = await PasswordResetToken.findOne({ token });
+        if (!existingToken) {
+            return res.status(400).json({ success: false, message: 'Invalid or expired reset token' });
+        }
+        if (existingToken.used) {
+            return res.status(400).json({ success: false, message: 'This reset token has already been used' });
+        }
         return res.status(400).json({ success: false, message: 'Reset token has expired' });
     }
 
@@ -694,11 +696,6 @@ const resetPassword = asyncHandler(async (req, res) => {
     user.password = hashedPassword;
     user.passwordChangedAt = new Date();
     await user.save();
-
-    // Mark token as used (single-use enforcement)
-    resetTokenDoc.used = true;
-    resetTokenDoc.usedAt = new Date();
-    await resetTokenDoc.save();
 
     await clearResetAttempts(user.email);
 


### PR DESCRIPTION
## Description

The `resetPassword` function in `controller/auth.js` used a non-atomic read-then-write pattern to validate and mark password reset tokens as used. Concurrent requests with the same reset token could both pass the `used === false` check before either marked the token as used, allowing the token to be used multiple times.

### Changes

1. **Replaced non-atomic read-then-write** with an atomic `findOneAndUpdate` that finds a valid unused, unexpired token and marks it `used: true` in a single database operation.
2. **Removed the separate `used = true` + `save()` call** after password update.
3. **Added fallback error detection** — if the atomic update returns null, the code re-checks the token to return a specific error (invalid, already used, or expired).

### Files Changed
- `controller/auth.js` — +14 / -17 lines

Closes #419