### PR TITLE
[SECURITY] Add express-mongo-sanitize to prevent NoSQL injection attacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ if (process.env.NODE_ENV !== "production") {
     dotenv.config({ path: ".env.local", override: true });
 }
 const cookieParser = require("cookie-parser");
+const mongoSanitize = require("express-mongo-sanitize");
 const express = require('express');
 const passport = require("passport");
 const path = require('path');
@@ -45,6 +46,7 @@ app.use(express.json({
         req.rawBody = buf;
     }
 }));
+app.use(mongoSanitize());
 app.use(generateCsrf);
 app.use(verifyCsrf);
 app.use(passport.initialize());

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.4.2",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
+        "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^8.5.2",
         "ioredis": "^5.11.1",
         "jsonwebtoken": "^9.0.3",
@@ -108,7 +109,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -533,6 +533,29 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -2349,7 +2372,6 @@
     "node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2576,7 +2598,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2771,7 +2792,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3292,8 +3312,7 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1624250",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -3563,7 +3582,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3600,6 +3618,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-mongo-sanitize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/express-rate-limit": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^17.4.2",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
+    "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^8.5.2",
     "ioredis": "^5.11.1",
     "jsonwebtoken": "^9.0.3",


### PR DESCRIPTION
## Summary

Implements automatic NoSQL injection prevention by sanitizing MongoDB query parameters, blocking operator-based attacks that bypass authentication or leak data.

## Problem

User-controlled input passed directly to MongoDB queries can be exploited:

**Attack Example:**
```json
POST /api/login
{ "email": { "$gt": "" }, "password": { "$gt": "" } }
```

The object syntax is interpreted as MongoDB query operators rather than equality checks, returning any matching user without verifying password.

## Solution

Installed express-mongo-sanitize middleware that:
1. Strips all `$` and `." characters from req.body, req.query, req.params
2. Converts malicious operator objects to strings
3. Ensures query filters are always primitive types (string/number)

## Changes

**package.json**:
- Added express-mongo-sanitize dependency

**index.js**:
- Imported mongoSanitize from express-mongo-sanitize
- Registered middleware after JSON parsing: `app.use(mongoSanitize())`
- Applied before route handlers to sanitize all incoming requests

## Impact

- ✅ Eliminates NoSQL injection via query operators
- ✅ Prevents authentication bypass attacks
- ✅ Protects data from unauthorized access
- ✅ Works transparently with existing code


## Related

Closes #447