### PR TITLE
fix(security): prevent error handler from exposing stack traces and file paths

### DIFF
--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,20 +1,59 @@
 const { wantsHtml } = require('../utils/requestType');
 
-/**
- * @function errorHandler
- * @description Global error handling middleware for formatting and sending error responses.
- * @returns {any}
- */
+function getSafeErrorMessage(err, isProduction) {
+  if (!err) return isProduction ? 'An internal error occurred.' : 'Unknown error';
+
+  const isClientError = err.status && err.status >= 400 && err.status < 500;
+  if (!isClientError && isProduction) {
+    return 'An internal error occurred.';
+  }
+
+  const message = err.message || (isClientError ? 'Bad Request' : 'Internal server error');
+  if (isProduction && isClientError) {
+    return sanitizeClientErrorMessage(message);
+  }
+
+  return message;
+}
+
+function sanitizeClientErrorMessage(message) {
+  if (!message || typeof message !== 'string') return 'Bad Request';
+
+  const safePatterns = [
+    'validation',
+    'not found',
+    'unauthorized',
+    'forbidden',
+    'bad request',
+    'conflict',
+    'duplicate',
+    'required',
+    'invalid',
+  ];
+
+  const lowerMessage = message.toLowerCase();
+  const isSafeMessage = safePatterns.some(pattern => lowerMessage.includes(pattern));
+
+  return isSafeMessage ? message : 'Bad Request';
+}
+
 function errorHandler(err, req, res, next) {
-  console.error(err);
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  console.error('[ERROR]', {
+    status: err.status || 500,
+    message: err.message,
+    stack: err.stack,
+    method: req.method,
+    path: req.path,
+    ip: req.ip,
+    timestamp: new Date().toISOString(),
+  });
+
   if (res.headersSent) return next(err);
 
   const status = err.status && Number.isInteger(err.status) ? err.status : 500;
-  const isClientError = status >= 400 && status < 500;
-  const isProduction = process.env.NODE_ENV === 'production';
-  const message = isClientError
-    ? (err.message || 'Bad Request')
-    : (isProduction ? 'Internal server error' : (err.message || 'Internal server error'));
+  const message = getSafeErrorMessage(err, isProduction);
 
   if (wantsHtml(req)) {
     return res.status(status).render('error', {

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -1,0 +1,134 @@
+const request = require('supertest');
+const express = require('express');
+const errorHandler = require('../middleware/errorHandler');
+
+describe('Error Handler Middleware', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Route that throws an error
+    app.get('/test-error', (req, res, next) => {
+      const err = new Error('Database connection failed');
+      err.status = 500;
+      next(err);
+    });
+
+    // Route that throws a client error
+    app.get('/test-validation-error', (req, res, next) => {
+      const err = new Error('Validation failed: invalid email format');
+      err.status = 400;
+      next(err);
+    });
+
+    // Route that throws error with full stack
+    app.get('/test-stack-error', (req, res, next) => {
+      try {
+        throw new Error('Test error with stack trace');
+      } catch (err) {
+        err.status = 500;
+        next(err);
+      }
+    });
+
+    app.use(errorHandler);
+  });
+
+  describe('Production mode (NODE_ENV=production)', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterEach(() => {
+      delete process.env.NODE_ENV;
+    });
+
+    it('should not expose stack traces for 5xx errors', async () => {
+      const response = await request(app)
+        .get('/test-error')
+        .set('Accept', 'application/json');
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        message: 'An internal error occurred.',
+        error: 'An internal error occurred.'
+      });
+
+      expect(response.body).not.toHaveProperty('stack');
+      expect(JSON.stringify(response.body)).not.toMatch(/\/middleware|errorHandler|Database connection/);
+    });
+
+    it('should sanitize client error messages', async () => {
+      const response = await request(app)
+        .get('/test-validation-error')
+        .set('Accept', 'application/json');
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch(/validation|invalid/i);
+      expect(response.body.message).not.toMatch(/\bfrom\b|\/home|\/tmp|\.js:/);
+    });
+
+    it('should not expose error details in JSON response', async () => {
+      const response = await request(app)
+        .get('/test-stack-error')
+        .set('Accept', 'application/json');
+
+      expect(response.status).toBe(500);
+      expect(JSON.stringify(response.body)).not.toMatch(/at /);
+      expect(JSON.stringify(response.body)).not.toMatch(/\(/);
+    });
+  });
+
+  describe('Development mode (NODE_ENV=development)', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+    });
+
+    afterEach(() => {
+      delete process.env.NODE_ENV;
+    });
+
+    it('should expose error messages for debugging', async () => {
+      const response = await request(app)
+        .get('/test-error')
+        .set('Accept', 'application/json');
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe('Database connection failed');
+    });
+
+    it('should not expose stack traces in JSON response even in development', async () => {
+      const response = await request(app)
+        .get('/test-stack-error')
+        .set('Accept', 'application/json');
+
+      expect(response.status).toBe(500);
+      expect(JSON.stringify(response.body)).not.toHaveProperty('stack');
+      expect(JSON.stringify(response.body)).not.toMatch(/at /);
+    });
+  });
+
+  it('should not process errors if headers already sent', (done) => {
+    const appWithHeadersSent = express();
+    appWithHeadersSent.use(express.json());
+
+    appWithHeadersSent.get('/test', (req, res, next) => {
+      res.status(200).send('OK');
+      const err = new Error('This should not be sent');
+      next(err);
+    });
+
+    appWithHeadersSent.use(errorHandler);
+
+    request(appWithHeadersSent)
+      .get('/test')
+      .end((err, res) => {
+        expect(res.status).toBe(200);
+        expect(res.text).toBe('OK');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
## Summary

Harden the error handler to prevent leaking stack traces, file paths, and internal architecture details to API clients, which could enable attackers to exploit other vulnerabilities more efficiently.

## Changes

- Add `sanitizeClientErrorMessage()` to whitelist safe client error categories
- Ensure all 5xx errors return generic message in production regardless of actual error
- Implement `getSafeErrorMessage()` wrapper enforcing production-safe responses
- Log full error details server-side for debugging without exposing to clients
- Add comprehensive test suite verifying no stack traces leak in any NODE_ENV mode

## Security Impact

Eliminates information disclosure vulnerability (CWE-209) that exposed file system paths, library versions, and internal error details to API callers.

Closes #449