### PR TITLE
fix: use atomic findOneAndUpdate in content publish worker (#471)

### DIFF
--- a/model/scheduledContent.js
+++ b/model/scheduledContent.js
@@ -40,6 +40,9 @@ const scheduledContentSchema = new mongoose.Schema(
         publishedAt: {
             type: Date,
         },
+        publishedBy: {
+            type: String,
+        },
     },
     { timestamps: true }
 );

--- a/workers/contentPublishWorker.js
+++ b/workers/contentPublishWorker.js
@@ -1,32 +1,36 @@
 const cron = require('node-cron');
 const ScheduledContent = require('../model/scheduledContent');
 
-// Runs every minute and publishes any content whose scheduledAt (stored in
-// UTC) has passed. Comparing against `new Date()` (also UTC internally)
-// means DST changes in the creator's local timezone can't cause an
-// off-by-one-hour publish - the timezone field on the document is display
-// metadata only, never used for the due-date comparison.
-//
-// NOTE: this only flips status to "published". There's no subscriber/
-// notification system in this codebase yet (no subscriber model, no email
-// dispatch for content updates), so the "notify subscribers" step from the
-// issue's proposed solution isn't included - wiring it in would mean
-// inventing a whole notification feature that's out of scope here.
+const INSTANCE_ID = process.env.INSTANCE_ID || `web-${process.pid}`;
+
 async function publishDueContent() {
     const now = new Date();
+    let publishedCount = 0;
 
-    const dueContent = await ScheduledContent.find({
-        status: 'scheduled',
-        scheduledAt: { $lte: now },
-    });
+    // Use atomic findOneAndUpdate to prevent race conditions in multi-instance deployments
+    while (true) {
+        const result = await ScheduledContent.findOneAndUpdate(
+            {
+                status: 'scheduled',
+                scheduledAt: { $lte: now },
+            },
+            {
+                $set: {
+                    status: 'published',
+                    publishedAt: now,
+                    publishedBy: INSTANCE_ID,
+                },
+            },
+            {
+                new: true,
+            }
+        );
 
-    for (const item of dueContent) {
-        item.status = 'published';
-        item.publishedAt = now;
-        await item.save();
+        if (!result) break;
+        publishedCount++;
     }
 
-    return dueContent.length;
+    return publishedCount;
 }
 
 function startContentPublishWorker() {


### PR DESCRIPTION
## Fix: Replace Find-Then-Save with Atomic findOneAndUpdate in Content Publish Worker (#471)

### Problem
The content publish worker used a non-atomic find-then-save pattern. In multi-instance deployments (Docker Compose with nginx), multiple instances could find and publish the same content simultaneously, causing double-publish.

### Changes

#### `workers/contentPublishWorker.js`
- Replaced `ScheduledContent.find()` + `item.save()` loop with atomic `findOneAndUpdate()`
- Each publish operation is now atomic and race-condition-safe
- Added instance identifier (`INSTANCE_ID`) for debugging

#### `model/scheduledContent.js`
- Added `publishedBy` field for audit trail

### Security Improvements
- Content is now published exactly once regardless of instance count
- Atomic operations prevent race conditions in multi-instance deployments
- Audit trail tracks which instance published each item

Closes #471