### PR TITLE
Add aria-hidden to decorative SVG icons and fix missing button labels

### DIFF
--- a/public/js/pages/login.js
+++ b/public/js/pages/login.js
@@ -1,14 +1,14 @@
-const googleLogin = document.querySelector('.google-login');
-const emailForm = document.querySelector('#email-login-form');
-const contributorForm = document.querySelector('#contributor-login-form');
+const googleLogin = document.querySelector(".google-login");
+const emailForm = document.querySelector("#email-login-form");
+const contributorForm = document.querySelector("#contributor-login-form");
 
 let emailLoading = false;
 let contributorLoading = false;
 
-googleLogin?.addEventListener('click', function () {
-this.setAttribute('aria-busy', 'true');
+googleLogin?.addEventListener("click", function () {
+  this.setAttribute("aria-busy", "true");
 
-```
+  ```
 const span = this.querySelector('span');
 
 if (span) {
@@ -16,14 +16,13 @@ if (span) {
 }
 
 this.disabled = true;
-```
-
+```;
 });
 
-emailForm?.addEventListener('submit', function () {
-if (emailLoading) return false;
+emailForm?.addEventListener("submit", function () {
+  if (emailLoading) return false;
 
-```
+  ```
 emailLoading = true;
 
 const submitButton = this.querySelector('button[type="submit"]');
@@ -37,14 +36,13 @@ if (submitButton) {
     submitButton.textContent =
         submitButton.dataset.loadingText || 'Signing in...';
 }
-```
-
+```;
 });
 
-contributorForm?.addEventListener('submit', async function (event) {
-event.preventDefault();
+contributorForm?.addEventListener("submit", async function (event) {
+  event.preventDefault();
 
-```
+  ```
 if (contributorLoading) return;
 
 contributorLoading = true;
@@ -91,33 +89,32 @@ try {
 } finally {
     contributorLoading = false;
 }
-```
-
+```;
 });
 
 // Show/Hide Password Toggle
-const togglePasswordBtn = document.querySelector('#toggle-password');
-const passwordInput = document.querySelector('#login-password');
+const togglePasswordBtn = document.querySelector("#toggle-password");
+const passwordInput = document.querySelector("#login-password");
 
-togglePasswordBtn?.addEventListener('click', function () {
-    const isPassword = passwordInput.getAttribute('type') === 'password';
-    passwordInput.setAttribute('type', isPassword ? 'text' : 'password');
-    
-    if (isPassword) {
-        this.innerHTML = `
-            <svg class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
+togglePasswordBtn?.addEventListener("click", function () {
+  const isPassword = passwordInput.getAttribute("type") === "password";
+  passwordInput.setAttribute("type", isPassword ? "text" : "password");
+
+  if (isPassword) {
+    this.innerHTML = `
+            <svg class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true">
                 <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
                 <line x1="1" y1="1" x2="23" y2="23"></line>
             </svg>
         `;
-        this.setAttribute('aria-label', 'Hide password');
-    } else {
-        this.innerHTML = `
-            <svg class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
+    this.setAttribute("aria-label", "Hide password");
+  } else {
+    this.innerHTML = `
+            <svg class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true">
                 <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
                 <circle cx="12" cy="12" r="3"></circle>
             </svg>
         `;
-        this.setAttribute('aria-label', 'Show password');
-    }
+    this.setAttribute("aria-label", "Show password");
+  }
 });

--- a/view/login.ejs
+++ b/view/login.ejs
@@ -553,7 +553,7 @@
                 <% } %>
 
                 <a class="social-btn" href="/auth/google">
-                    <svg class="social-icon" viewBox="0 0 48 48">
+                    <svg class="social-icon" viewBox="0 0 48 48" aria-hidden="true">
                         <path fill="#EA4335" d="M24 9.5c3.5 0 6.5 1.2 8.9 3.5l6.6-6.6C35.5 2.7 30.3.5 24 .5 14.8.5 6.9 5.8 3.1 13.5l7.7 6C12.6 13.6 17.8 9.5 24 9.5z"/>
                         <path fill="#4285F4" d="M46.6 24.5c0-1.6-.1-3.1-.4-4.5H24v8.5h12.7c-.6 2.9-2.2 5.4-4.8 7.1l7.4 5.7c4.3-4 7.3-9.9 7.3-16.8z"/>
                         <path fill="#FBBC05" d="M10.8 28.5c-.5-1.4-.8-2.9-.8-4.5s.3-3.1.8-4.5l-7.7-6C1.5 16.7.6 20.2.6 24s.9 7.3 2.5 10.5l7.7-6z"/>
@@ -563,7 +563,7 @@
                 </a>
 
                 <button class="social-btn" type="button" onclick="alert('Instagram login coming soon!')">
-                    <svg class="social-icon" viewBox="0 0 24 24" fill="none" stroke="#E1306C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <svg class="social-icon" viewBox="0 0 24 24" fill="none" stroke="#E1306C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
                         <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path>
                         <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
@@ -593,7 +593,7 @@
                         <div class="password-wrapper">
                             <input id="login-password" type="password" name="password" placeholder="••••••••" required>
                             <button type="button" id="toggle-password" class="password-toggle-btn" aria-label="Show password">
-                                <svg class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
+                                <svg class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true">
                                     <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
                                     <circle cx="12" cy="12" r="3"></circle>
                                 </svg>

--- a/view/partials/dashboard/_link_actions.ejs
+++ b/view/partials/dashboard/_link_actions.ejs
@@ -4,7 +4,7 @@
 %>
 <div class="row-actions">
   <a class="row-action" href="#analytics" aria-label="View analytics">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
       <path d="M4 19V5"></path>
       <path d="M9 19v-6"></path>
       <path d="M14 19V9"></path>
@@ -12,7 +12,7 @@
     </svg>
   </a>
   <a class="row-action" href="/services/url-shortener" aria-label="Edit link">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
       <path d="M12 20h9"></path>
       <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
     </svg>

--- a/view/partials/layout/sidebar.ejs
+++ b/view/partials/layout/sidebar.ejs
@@ -13,20 +13,20 @@
     <nav class="sidebar-section">
         <p class="sidebar-label">Workspace</p>
         <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'dashboard' ? 'active' : '' %>" href="/dashboard">
-            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
             <span class="nav-text">Dashboard</span>
         </a>
         <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'my-links' ? 'active' : '' %>" href="/services/url-shortener">
-            <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11 4.9"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 0 0 7.07 7.07L13 19.1"></path></svg>
             <span class="nav-text">My Links</span>
         </a>
         <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'analytics' ? 'active' : '' %>" href="/services/analytics-dashboard">
-            <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19V5"></path><path d="M9 19V9"></path><path d="M14 19V3"></path><path d="M19 19v-7"></path></svg>
             <span class="nav-text">Analytics</span>
         </a>
        
         <a class="nav-link <%= typeof activeNav !== 'undefined' && activeNav === 'settings' ? 'active' : '' %>" href="/settings">
-            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 20.4a1.65 1.65 0 0 0-1.82-.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6V3a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 15 3.6l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15Z"></path></svg>
             <span class="nav-text">Settings</span>
         </a>
     </nav>
@@ -37,7 +37,7 @@
         <% if (typeof services !== 'undefined' && services && services.length) { %>
             <% services.forEach((service) => { %>
                 <a class="service-link <%= typeof activeNav !== 'undefined' && activeNav === service.route ? 'active' : '' %> <%= service.status %>" href="<%= service.route %>" title="<%= service.name %>">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <% if (service.svgPath) { %>
                             <%- service.svgPath %>
                         <% } else { %>
@@ -57,7 +57,7 @@
             <button class="upgrade-btn" type="button">Upgrade</button>
         </div>
         <a class="nav-link" href="/logout">
-            <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"></path></svg>
             <span class="nav-text">Logout</span>
         </a>
     </div>

--- a/view/partials/layout/topbar.ejs
+++ b/view/partials/layout/topbar.ejs
@@ -1,26 +1,26 @@
 <header class="topbar">
     <button class="menu-btn" type="button" aria-label="Toggle sidebar" id="sidebarToggle">
-        <svg viewBox="0 0 24 24"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"></path></svg>
     </button>
 
     <div class="search-container">
-        <svg class="search-icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+        <svg class="search-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
         <input type="text" id="search-links-input" class="search-input" placeholder="<%= typeof searchPlaceholder !== 'undefined' ? searchPlaceholder : 'Search shortened links...' %>" />
     </div>
 
     <div class="topbar-actions">
         <button id="theme-toggle" class="action-icon-btn" type="button" aria-label="Toggle Theme">
-            <svg class="icon-light" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto;"><path d="M7.5 1.5V2.5M7.5 12.5V13.5M1.5 7.5H2.5M12.5 7.5H13.5M3.257 3.257L3.964 3.964M11.035 11.035L11.742 11.742M3.257 11.742L3.964 11.035M11.035 3.964L11.742 3.257" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/><circle cx="7.5" cy="7.5" r="2.75" stroke="currentColor" stroke-width="1.5"/></svg>
-            <svg class="icon-dark" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto; display:none;"><path d="M1.66 7.452C1.66 10.67 4.268 13.278 7.485 13.278C10.02 13.278 12.18 11.65 12.987 9.388C12.103 10.199 10.899 10.706 9.57 10.706C6.884 10.706 4.706 8.528 4.706 5.842C4.706 4.542 5.193 3.364 5.976 2.493C3.541 3.195 1.66 5.128 1.66 7.453Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
+            <svg class="icon-light" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto;" aria-hidden="true"><path d="M7.5 1.5V2.5M7.5 12.5V13.5M1.5 7.5H2.5M12.5 7.5H13.5M3.257 3.257L3.964 3.964M11.035 11.035L11.742 11.742M3.257 11.742L3.964 11.035M11.035 3.964L11.742 3.257" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/><circle cx="7.5" cy="7.5" r="2.75" stroke="currentColor" stroke-width="1.5"/></svg>
+            <svg class="icon-dark" width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin:auto; display:none;" aria-hidden="true"><path d="M1.66 7.452C1.66 10.67 4.268 13.278 7.485 13.278C10.02 13.278 12.18 11.65 12.987 9.388C12.103 10.199 10.899 10.706 9.57 10.706C6.884 10.706 4.706 8.528 4.706 5.842C4.706 4.542 5.193 3.364 5.976 2.493C3.541 3.195 1.66 5.128 1.66 7.453Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
         </button>
-        <button class="action-icon-btn" type="button"><svg viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
+        <button class="action-icon-btn" type="button" aria-label="Notifications"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"></path></svg></button>
         <a class="profile-chip" href="/profile">
             <span class="avatar"><%= typeof user !== 'undefined' ? user.initials : 'U' %></span>
             <span class="profile-name"><%= typeof user !== 'undefined' ? user.name : 'User' %></span>
         </a>
         <% if (typeof hideCta === 'undefined' || !hideCta) { %>
         <a class="primary-action-btn" href="<%= typeof ctaLink !== 'undefined' ? ctaLink : '/services/url-shortener' %>">
-            <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;"><path d="M12 5v14M5 12h14"></path></svg>
+            <svg viewBox="0 0 24 24" style="width:1.25rem; height:1.25rem; stroke:currentColor; stroke-width:2.5; fill:none;" aria-hidden="true"><path d="M12 5v14M5 12h14"></path></svg>
             <%= typeof ctaText !== 'undefined' ? ctaText : 'Create Link' %>
         </a>
         <% } %>

--- a/view/signup.ejs
+++ b/view/signup.ejs
@@ -483,19 +483,19 @@
                 <h3>Why go Pro?</h3>
                 <ul class="feature-list">
                     <li>
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <path d="M20 6L9 17l-5-5"></path>
                         </svg>
                         Unlimited Smart Links
                     </li>
                     <li>
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <path d="M20 6L9 17l-5-5"></path>
                         </svg>
                         Advanced CRM & Leads
                     </li>
                     <li>
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <path d="M20 6L9 17l-5-5"></path>
                         </svg>
                         Custom .creator Domains
@@ -543,7 +543,7 @@
                     <% } %>
 
                     <a class="social-btn" href="/auth/google">
-                        <svg class="social-icon" viewBox="0 0 48 48">
+                        <svg class="social-icon" viewBox="0 0 48 48" aria-hidden="true">
                             <path fill="#EA4335" d="M24 9.5c3.5 0 6.5 1.2 8.9 3.5l6.6-6.6C35.5 2.7 30.3.5 24 .5 14.8.5 6.9 5.8 3.1 13.5l7.7 6C12.6 13.6 17.8 9.5 24 9.5z"/>
                             <path fill="#4285F4" d="M46.6 24.5c0-1.6-.1-3.1-.4-4.5H24v8.5h12.7c-.6 2.9-2.2 5.4-4.8 7.1l7.4 5.7c4.3-4 7.3-9.9 7.3-16.8z"/>
                             <path fill="#FBBC05" d="M10.8 28.5c-.5-1.4-.8-2.9-.8-4.5s.3-3.1.8-4.5l-7.7-6C1.5 16.7.6 20.2.6 24s.9 7.3 2.5 10.5l7.7-6z"/>


### PR DESCRIPTION
Closes #274
## 📝 Description
Improves image/icon accessibility for screen reader users. All `<img>` tags in the codebase already had appropriate `alt` attributes, so the actual gap was in inline `<svg>` icons — they had no `aria-hidden` or labeling, causing screen readers to announce raw, meaningless SVG content alongside adjacent visible text or labels.

## 🔗 Related Issues
Fixes #274

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔄 Changes Made
- Added `aria-hidden="true"` to all decorative SVG icons that sit beside existing visible text or an `aria-label`'d parent control, across `view/partials/layout/sidebar.ejs`, `view/partials/layout/topbar.ejs`, `view/partials/dashboard/_link_actions.ejs`, `view/login.ejs`, and `view/signup.ejs`
- Added a missing `aria-label="Notifications"` to the previously unlabeled bell icon button in `view/partials/layout/topbar.ejs` — this button had no accessible name at all before this fix
- Fixed `public/js/pages/login.js` so the password show/hide toggle's dynamically injected SVG markup carries `aria-hidden="true"` on every swap (the `aria-label` toggle between "Show password"/"Hide password" was already correct, but the re-injected icon markup dropped the hidden attribute each time)

## ✅ Testing
### How to Test
1. Open the login, signup, or dashboard pages with a screen reader (e.g. NVDA, VoiceOver) or browser accessibility inspector
2. Tab through nav links, the password toggle, and the notification bell
3. Confirm decorative icons are silent and each interactive control announces a clear, correct label

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
N/A — changes are accessibility-tree only, no visual changes.

## 🚀 Deployment Notes
None — purely markup/attribute changes, no backend or build impact.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Other files with inline SVGs (e.g. `dashboard.ejs`, `services-hub.ejs`, `vault.ejs`) still have similar gaps and could be a good follow-up PR if useful.

---