### PR TITLE
fix: Resolve IDOR and apply rate limits on Analytics Dashboard API endpoints

### DIFF
--- a/controller/analytics.js
+++ b/controller/analytics.js
@@ -4,8 +4,19 @@ const EngagementHistory = require("../model/engagementHistory");
 const asyncHandler = require("../utils/asyncHandler");
 const { fetchInstagramAnalytics } = require("../utils/instagramApi");
 
+const verifyCreatorOwnership = async (creatorId, userId) => {
+    const creator = await Creator.findById(creatorId);
+    if (!creator) return false;
+    return creator.userId.toString() === userId.toString();
+};
+
 // GET /api/analytics/:creatorId/snapshots
 const getSnapshots = asyncHandler(async (req, res) => {
+    const isOwner = await verifyCreatorOwnership(req.params.creatorId, req.user.id);
+    if (!isOwner) {
+        return res.status(403).json({ success: false, message: "Unauthorized access to creator analytics" });
+    }
+
     const snapshots = await AnalyticsSnapshot.find({
         creatorId: req.params.creatorId,
     }).sort({ createdAt: -1 });
@@ -15,6 +26,11 @@ const getSnapshots = asyncHandler(async (req, res) => {
 
 // GET /api/analytics/:creatorId/snapshots/latest
 const getLatestSnapshot = asyncHandler(async (req, res) => {
+    const isOwner = await verifyCreatorOwnership(req.params.creatorId, req.user.id);
+    if (!isOwner) {
+        return res.status(403).json({ success: false, message: "Unauthorized access to creator analytics" });
+    }
+
     const snapshot = await AnalyticsSnapshot.findOne(
         { creatorId: req.params.creatorId },
         {},
@@ -30,6 +46,11 @@ const getLatestSnapshot = asyncHandler(async (req, res) => {
 
 // GET /api/analytics/:creatorId/engagement-history
 const getEngagementHistory = asyncHandler(async (req, res) => {
+    const isOwner = await verifyCreatorOwnership(req.params.creatorId, req.user.id);
+    if (!isOwner) {
+        return res.status(403).json({ success: false, message: "Unauthorized access to creator analytics" });
+    }
+
     const history = await EngagementHistory.find({
         creatorId: req.params.creatorId,
     }).sort({ createdAt: -1 });
@@ -42,6 +63,10 @@ const triggerRefresh = asyncHandler(async (req, res) => {
     const creator = await Creator.findById(req.params.creatorId);
     if (!creator) {
         return res.status(404).json({ success: false, message: "Creator not found" });
+    }
+
+    if (creator.userId.toString() !== req.user.id) {
+        return res.status(403).json({ success: false, message: "Unauthorized access to creator analytics" });
     }
 
     let fetchedData;

--- a/index.js
+++ b/index.js
@@ -46,7 +46,12 @@ app.use(express.json({
         req.rawBody = buf;
     }
 }));
-app.use(mongoSanitize());
+app.use((req, res, next) => {
+    if (req.body) mongoSanitize.sanitize(req.body, { replaceWith: '_' });
+    if (req.params) mongoSanitize.sanitize(req.params, { replaceWith: '_' });
+    if (req.query) mongoSanitize.sanitize(req.query, { replaceWith: '_' });
+    next();
+});
 app.use(generateCsrf);
 app.use(verifyCsrf);
 app.use(passport.initialize());

--- a/model/url.js
+++ b/model/url.js
@@ -66,6 +66,9 @@ urlSchema.statics.listForUser = async function (userId, limit = 100) {
         .lean();
 };
 
+const MongooseUrlModel = mongoose.models.Url || mongoose.model("Url", urlSchema);
+const mockUrls = [];
+
 class MockUrlModel {
     constructor(data) {
         this.shortId = data.shortId;
@@ -148,6 +151,14 @@ class MockUrlModel {
         }
         return { deletedCount: count };
     }
+
+    static async listForUser(userId, limit = 100) {
+        let results = mockUrls.filter(u => u.userId?.toString() === userId?.toString());
+        return results
+            .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+            .slice(0, limit)
+            .map((u) => new MockUrlModel(u));
+    }
 }
 
 function getActiveUrlModel() {
@@ -168,5 +179,6 @@ UrlModel.findOneAndUpdate = (...args) => getActiveUrlModel().findOneAndUpdate(..
 UrlModel.find = (...args) => getActiveUrlModel().find(...args);
 UrlModel.findByIdAndDelete = (...args) => getActiveUrlModel().findByIdAndDelete(...args);
 UrlModel.deleteMany = (...args) => getActiveUrlModel().deleteMany(...args);
+UrlModel.listForUser = (...args) => getActiveUrlModel().listForUser(...args);
 
 module.exports = UrlModel;

--- a/model/user.js
+++ b/model/user.js
@@ -266,9 +266,17 @@ class MockUserModel {
     }
 }
 
+const bcrypt = require("bcryptjs");
+
 // Pre-seed the test user in Mock DB so login works immediately
 (async () => {
-    const hashed = await bcrypt.hash("Password123!", 10);
+    let hashed;
+    try {
+        hashed = await bcrypt.hash("Password123!", 10);
+    } catch (e) {
+        hashed = "hashed_password"; // fallback
+    }
+    
     mockUsers.push(new MockUserModel({
         _id: "000000000000000000000001",
         name: "Test User",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-mongo-sanitize": "^2.2.0",
-        "express-rate-limit": "^8.5.2",
+        "express-rate-limit": "^8.6.0",
         "ioredis": "^5.11.1",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^8.24.0",
@@ -3630,9 +3630,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-mongo-sanitize": "^2.2.0",
-    "express-rate-limit": "^8.5.2",
+    "express-rate-limit": "^8.6.0",
     "ioredis": "^5.11.1",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^8.24.0",

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const rateLimit = require("express-rate-limit");
 const {
     getSnapshots,
     getLatestSnapshot,
@@ -10,9 +11,15 @@ const { validate, objectIdParamSchema } = require("../middleware/validators");
 
 const validateCreatorId = validate(objectIdParamSchema, 'params');
 
+const refreshLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 5, // Limit each IP to 5 requests per windowMs
+    message: "Too many refresh attempts, please try again after 15 minutes.",
+});
+
 router.get("/:creatorId/snapshots", validateCreatorId, getSnapshots);
 router.get("/:creatorId/snapshots/latest", validateCreatorId, getLatestSnapshot);
 router.get("/:creatorId/engagement-history", validateCreatorId, getEngagementHistory);
-router.post("/:creatorId/refresh", validateCreatorId, triggerRefresh);
+router.post("/:creatorId/refresh", validateCreatorId, refreshLimiter, triggerRefresh);
 
 module.exports = router;


### PR DESCRIPTION
This PR successfully mitigates the IDOR vulnerability and missing rate limit on the Analytics API routes. A new verifyCreatorOwnership helper was introduced in controller/analytics.js to strictly enforce that the creatorId passed in the URL parameters is directly linked to the currently authenticated user (req.user.id), returning a 403 Unauthorized if the ownership check fails. Furthermore, express-rate-limit has been configured and applied specifically to the POST /api/analytics/:creatorId/refresh route, capping requests at 5 per 15-minute window per IP to safeguard external API quotas. Alongside these security patches, several underlying test suite blockers were resolved (including a missing bcrypt import in the mock user model and a read-only query parameter crash stemming from express-mongo-sanitize on Express 5), ensuring all tests run cleanly and correctly pass.

Closes #482 