### PR TITLE
fix: Enforce email verification for dashboard invite acceptance

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -172,11 +172,17 @@ const acceptInviteFromDashboard = asyncHandler(async (req, res, next) => {
 
     const { inviteToken } = result.data;
 
+    const userDoc = await User.findById(req.user.id).select('email').lean();
+    if (!userDoc) {
+      return renderDashboard(req, res, { inviteAcceptError: 'User not found.' });
+    }
+
     // Atomically claim the invite: find a pending invite and mark it accepted in one operation
     const invite = await Invite.findOneAndUpdate(
       {
         token: inviteToken.trim(),
         status: 'pending',
+        email: userDoc.email.trim().toLowerCase(), // Security fix: Verify email matches!
         $or: [
           { expiresAt: { $exists: false } },
           { expiresAt: null },


### PR DESCRIPTION
This PR addresses a critical logic flaw in the team invitation system that allowed unverified users to claim leaked invite tokens. The acceptInviteFromDashboard controller in controller/collaborationController.js has been updated to query the authenticated user's email address and strictly enforce an email match during the token validation step. By adding email: userDoc.email.trim().toLowerCase() to the Mongoose update query, the backend now atomically guarantees that the user attempting to accept the invitation is the exact same user the invitation was originally intended for. Unauthorized users attempting to use a leaked token will now be properly rejected with an error, restoring secure access control to the creator CRM.

Closes #484 