### PR TITLE
feat: implement Zustag state management library and refactor page state (#170)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -537,6 +536,29 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -2391,7 +2413,6 @@
     "node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2617,7 +2638,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2879,7 +2899,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3693,7 +3712,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8347,7 +8365,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/public/js/pages/my-links.js
+++ b/public/js/pages/my-links.js
@@ -11,9 +11,27 @@
     const resultBanner = document.getElementById('result-banner');
     const resultText = document.getElementById('result-text');
 
-    let allLinks = [];
-    let sortMode = 'date';
-    let lastCreatedUrl = '';
+    // Initialize Zustag store
+    const useStore = window.zustag.createStore((set, get) => ({
+        allLinks: [],
+        sortMode: 'date',
+        lastCreatedUrl: '',
+    }));
+
+    // Subscribe to store changes to trigger UI updates
+    useStore.subscribe((state, prevState) => {
+        if (state.allLinks !== prevState.allLinks || state.sortMode !== prevState.sortMode) {
+            renderLinks();
+        }
+        if (state.lastCreatedUrl !== prevState.lastCreatedUrl) {
+            if (state.lastCreatedUrl) {
+                resultText.textContent = state.lastCreatedUrl;
+                resultBanner.style.display = 'flex';
+            } else {
+                resultBanner.style.display = 'none';
+            }
+        }
+    });
 
     function showToast(message, isError) {
         toastEl.textContent = message;
@@ -45,6 +63,7 @@
 
     function filterAndSortLinks() {
         const query = searchInput.value.trim().toLowerCase();
+        const { allLinks, sortMode } = useStore.getState();
         let links = [...allLinks];
 
         if (query) {
@@ -66,14 +85,14 @@
         return links;
     }
 
-   function renderLinks() {
-    const skeleton = document.getElementById('links-skeleton');
+    function renderLinks() {
+        const skeleton = document.getElementById('links-skeleton');
 
-    if (skeleton) {
-        skeleton.style.display = 'none';
-    }
+        if (skeleton) {
+            skeleton.style.display = 'none';
+        }
 
-    const links = filterAndSortLinks();
+        const links = filterAndSortLinks();
         feedEl.querySelectorAll('.link-card').forEach((el) => el.remove());
 
         if (links.length === 0) {
@@ -174,12 +193,11 @@
     async function loadLinks() {
         try {
             const data = await apiRequest('/api/urls');
-            allLinks = data.links || [];
+            useStore.setState({ allLinks: data.links || [] });
             updateStats(data.stats || { totalLinks: 0, totalClicksLabel: '0', topLinkTitle: '—' });
             if (data.domain) {
                 document.getElementById('domain-label').textContent = data.domain + '/';
             }
-            renderLinks();
         } catch (err) {
             showToast(err.message, true);
         }
@@ -188,7 +206,48 @@
     emptyEl.style.display = 'none';
     loadLinks();
 
+    // Form Submit Handler utilizing the store
+    if (shortenForm) {
+        shortenForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const redirectUrl = document.getElementById('redirect-url').value.trim();
+            const customSlug = document.getElementById('custom-slug').value.trim();
+            const linkTitle = document.getElementById('link-title').value.trim();
+            const linkTag = document.getElementById('link-tag').value;
+
+            try {
+                const data = await apiRequest('/api/urls', {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        redirectUrl,
+                        customSlug: customSlug || undefined,
+                        title: linkTitle || undefined,
+                        tag: linkTag
+                    })
+                });
+
+                // Prepend new link to state & store short URL
+                const { allLinks } = useStore.getState();
+                useStore.setState({
+                    allLinks: [data.link, ...allLinks],
+                    lastCreatedUrl: data.link.shortUrl
+                });
+
+                // Clear input fields
+                document.getElementById('redirect-url').value = '';
+                document.getElementById('custom-slug').value = '';
+                document.getElementById('link-title').value = '';
+                document.getElementById('link-tag').value = 'active';
+
+                showToast('Short link created successfully!');
+            } catch (err) {
+                showToast(err.message, true);
+            }
+        });
+    }
+
     document.getElementById('copy-result-btn').addEventListener('click', () => {
+        const { lastCreatedUrl } = useStore.getState();
         if (lastCreatedUrl) copyText(lastCreatedUrl, 'Short link copied!');
     });
 
@@ -199,17 +258,15 @@
     searchInput.addEventListener('input', renderLinks);
 
     document.getElementById('sort-date').addEventListener('click', () => {
-        sortMode = 'date';
+        useStore.setState({ sortMode: 'date' });
         document.getElementById('sort-date').classList.add('active');
         document.getElementById('sort-clicks').classList.remove('active');
-        renderLinks();
     });
 
     document.getElementById('sort-clicks').addEventListener('click', () => {
-        sortMode = 'clicks';
+        useStore.setState({ sortMode: 'clicks' });
         document.getElementById('sort-clicks').classList.add('active');
         document.getElementById('sort-date').classList.remove('active');
-        renderLinks();
     });
 
     document.getElementById('scroll-shorten-btn').addEventListener('click', () => {
@@ -223,13 +280,13 @@
 
     const emptyCTA = document.getElementById('empty-state-cta');
 
-if (emptyCTA) {
-    emptyCTA.addEventListener('click', () => {
-        document.getElementById('shorten-section')
-            ?.scrollIntoView({ behavior: 'smooth' });
+    if (emptyCTA) {
+        emptyCTA.addEventListener('click', () => {
+            document.getElementById('shorten-section')
+                ?.scrollIntoView({ behavior: 'smooth' });
 
-        document.getElementById('redirect-url')
-            ?.focus();
-    });
-}
+            document.getElementById('redirect-url')
+                ?.focus();
+        });
+    }
 })();

--- a/public/js/zustag.js
+++ b/public/js/zustag.js
@@ -1,0 +1,41 @@
+/**
+ * Zustag - A lightweight, Zustand-inspired state management library for vanilla JavaScript.
+ */
+(function(global) {
+    'use strict';
+
+    function createStore(createState) {
+        let state;
+        const listeners = new Set();
+
+        const setState = (partial, replace) => {
+            const nextState = typeof partial === 'function' ? partial(state) : partial;
+            if (!Object.is(nextState, state)) {
+                const previousState = state;
+                state = (replace ?? (typeof nextState !== 'object' || nextState === null))
+                    ? nextState
+                    : Object.assign({}, state, nextState);
+                listeners.forEach((listener) => listener(state, previousState));
+            }
+        };
+
+        const getState = () => state;
+
+        const subscribe = (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        };
+
+        const destroy = () => {
+            listeners.clear();
+        };
+
+        const api = { setState, getState, subscribe, destroy };
+        state = createState(setState, getState, api);
+        return api;
+    }
+
+    global.zustag = {
+        createStore
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/view/partials/layout/header.ejs
+++ b/view/partials/layout/header.ejs
@@ -12,6 +12,7 @@
     <%- include('../_brand_head') %>
     <%- include('../_fonts') %>
     <link href="/css/dashboard-layout.css" rel="stylesheet">
+    <script src="/js/zustag.js"></script>
     <% if (typeof extraHead !== 'undefined') { %>
         <%- extraHead %>
     <% } %>


### PR DESCRIPTION
## 📝 Description
This PR introduces a lightweight, Zustand-inspired state management library called **Zustag** to manage frontend state reactively, replacing raw variable mutations with store subscriptions.

## 🔗 Related Issues
Fixes #170

## 📋 Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Code refactoring

## 🔄 Changes Made
- Created `public/js/zustag.js` implementing a vanilla-JS compatible state store with `createStore`, `getState`, `setState`, and `subscribe`.
- Added the script reference globally inside `view/partials/layout/header.ejs` to ensure its availability across all dashboard pages.
- Refactored `public/js/pages/my-links.js` to manage UI states (`allLinks`, `sortMode`, `lastCreatedUrl`) using a new centralized store.
- Replaced direct event-driven manual view updates with reactive state subscriptions via the new store.

## ✅ Testing

### How to Test
1. Launch the application locally using `npm run dev`.
2. Navigate to the Shortlinks section.
3. Verify that adding a link dynamically adds it to the list and updates the widgets reactively.
4. Verify that sorting by Date or Clicks correctly updates the listed elements using the store's subscribers.

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots or GIFs showing the changes -->

## 🚀 Deployment Notes
<!-- Any special deployment steps or considerations? -->

## ⚠️ Breaking Changes
- None

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My PR title follows the naming convention
- [x] I have linked related issues
