### PR TITLE
fix(billing): persist stripe subscription state used by settings billing

### DIFF
--- a/controller/billing.js
+++ b/controller/billing.js
@@ -16,14 +16,20 @@ const createCheckoutSession = asyncHandler(async (req, res) => {
         return res.json({ success: true, url: "/dashboard?mockStripeCheckout=success" });
     }
 
+    const resolvedPriceId = priceId || process.env.STRIPE_PRO_PRICE_ID;
+    if (!resolvedPriceId || !process.env.BASE_URL) {
+        console.error("Stripe checkout misconfigured: missing STRIPE_PRO_PRICE_ID or BASE_URL");
+        return res.status(500).json({ success: false, message: "Billing is not configured correctly" });
+    }
+
     const user = req.user;
-    
+
     try {
         const session = await stripe.checkout.sessions.create({
             payment_method_types: ["card"],
             line_items: [
                 {
-                    price: priceId || process.env.STRIPE_PRO_PRICE_ID,
+                    price: resolvedPriceId,
                     quantity: 1,
                 },
             ],
@@ -31,7 +37,7 @@ const createCheckoutSession = asyncHandler(async (req, res) => {
             success_url: `${process.env.BASE_URL}/dashboard?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
             cancel_url: `${process.env.BASE_URL}/dashboard?checkout=cancelled`,
             customer_email: user.email,
-            client_reference_id: user._id.toString(),
+            client_reference_id: user.id,
         });
 
         res.json({ success: true, url: session.url });
@@ -55,14 +61,61 @@ const handleWebhook = asyncHandler(async (req, res) => {
         }
     }
 
-    if (event.type === "checkout.session.completed") {
-        const session = event.data.object;
-        const userId = session.client_reference_id;
-        
-        if (userId) {
-            await User.findByIdAndUpdate(userId, { tier: "pro", stripeCustomerId: session.customer });
-            console.log(`User ${userId} upgraded to Pro tier via webhook`);
+    switch (event.type) {
+        case "checkout.session.completed": {
+            const session = event.data.object;
+            const userId = session.client_reference_id;
+
+            if (userId) {
+                const subscription = session.subscription
+                    ? await stripe.subscriptions.retrieve(session.subscription)
+                    : null;
+
+                await User.findByIdAndUpdate(userId, {
+                    "subscription.status": "active",
+                    "subscription.stripeCustomerId": session.customer,
+                    "subscription.stripeSubscriptionId": session.subscription,
+                    "subscription.priceId": subscription?.items?.data?.[0]?.price?.id,
+                    "subscription.currentPeriodEnd": subscription?.current_period_end
+                        ? new Date(subscription.current_period_end * 1000)
+                        : undefined,
+                    "subscription.cancelAtPeriodEnd": subscription?.cancel_at_period_end ?? false,
+                });
+                console.log(`User ${userId} subscription activated via webhook`);
+            }
+            break;
         }
+
+        case "customer.subscription.updated": {
+            const subscription = event.data.object;
+            const user = await User.findOne({ "subscription.stripeCustomerId": subscription.customer });
+
+            if (user) {
+                await User.findByIdAndUpdate(user._id, {
+                    "subscription.status": subscription.status === "active" ? "active" : subscription.status,
+                    "subscription.priceId": subscription.items?.data?.[0]?.price?.id,
+                    "subscription.currentPeriodEnd": new Date(subscription.current_period_end * 1000),
+                    "subscription.cancelAtPeriodEnd": subscription.cancel_at_period_end,
+                });
+            }
+            break;
+        }
+
+        case "customer.subscription.deleted": {
+            const subscription = event.data.object;
+            const user = await User.findOne({ "subscription.stripeCustomerId": subscription.customer });
+
+            if (user) {
+                await User.findByIdAndUpdate(user._id, {
+                    "subscription.status": "canceled",
+                    "subscription.cancelAtPeriodEnd": false,
+                });
+            }
+            break;
+        }
+
+        default:
+            break;
     }
 
     res.json({ received: true });

--- a/model/user.js
+++ b/model/user.js
@@ -76,11 +76,17 @@ const userSchema = new mongoose.Schema(
         },
 
         subscription: {
+            status: { type: String, enum: ['inactive', 'active', 'canceled'], default: 'inactive' },
             planName: { type: String, default: 'Pro Individual' },
             priceMonthly: { type: Number, default: 29 },
             nextInvoiceDate: { type: Date },
             cardBrand: { type: String, default: 'VISA' },
             cardLast4: { type: String, default: '4242' },
+            stripeCustomerId: { type: String },
+            stripeSubscriptionId: { type: String },
+            priceId: { type: String },
+            currentPeriodEnd: { type: Date },
+            cancelAtPeriodEnd: { type: Boolean, default: false },
         },
 
         lastLoginAt: {

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -28,6 +28,7 @@ function buildBillingPayload(user) {
         })();
 
     return {
+        status: sub.status || 'inactive',
         planName: sub.planName || 'Pro Individual',
         priceMonthly: sub.priceMonthly ?? 29,
         nextInvoiceDate: nextInvoice.toISOString(),
@@ -39,6 +40,7 @@ function buildBillingPayload(user) {
         estimatedTotal: `$${(sub.priceMonthly ?? 29).toFixed(2)} USD`,
         cardBrand: sub.cardBrand || 'VISA',
         cardLast4: sub.cardLast4 || '4242',
+        cancelAtPeriodEnd: sub.cancelAtPeriodEnd ?? false,
         invoices: defaultInvoices(),
     };
 }


### PR DESCRIPTION
## Description
Checkout and webhook handling for billing didn't line up with the rest of the auth/data model, so a successful Stripe payment never actually showed up as a paid plan anywhere in the app.

## Related Issues
Fixes #502

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `createCheckoutSession` now uses `req.user.id` for `client_reference_id` instead of `req.user._id`, which doesn't exist on the JWT payload
- added a config check for `STRIPE_PRO_PRICE_ID` and `BASE_URL` before creating a session so we fail fast with a clear error instead of building a session with `undefined` redirect urls
- webhook handler now writes into `user.subscription` (status, stripeCustomerId, stripeSubscriptionId, priceId, currentPeriodEnd, cancelAtPeriodEnd) instead of top-level `tier`/`stripeCustomerId` fields that nothing else in the app reads
- added handling for `customer.subscription.updated` and `customer.subscription.deleted` so renewals and cancellations keep the stored state accurate
- `model/user.js` subscription schema now has the fields above
- `/api/settings/billing` payload now includes `status` and `cancelAtPeriodEnd`

## Testing

### How to Test
1. Set `STRIPE_SECRET_KEY`, `STRIPE_PRO_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`, `BASE_URL` in env
2. Authenticate and call `POST /api/billing/checkout`
3. Complete checkout in Stripe test mode, or simulate a `checkout.session.completed` event via the Stripe CLI
4. Call `GET /api/settings/billing` and confirm `status` is `active` and the plan/card info reflects the subscription

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

Ran the existing jest suite locally, no regressions introduced (there are 6 pre-existing failures in `tests/controllers/auth.test.js` unrelated to billing that also fail on main before this change).

## Breaking Changes
- None. `subscription.stripeCustomerId` etc. are new fields, existing documents just default to `inactive` status.

## Additional Context
This depends on the auth middleware export fix already merged in main (#506), which is required for these routes to load at all.
