### PR TITLE
fix(security): remove hardcoded Instagram webhook verification token fallback

### DIFF
--- a/controller/instagramWebhookController.js
+++ b/controller/instagramWebhookController.js
@@ -5,8 +5,12 @@ const crypto = require('crypto');
 
 // Verify the webhook from Meta
 const verifyWebhook = (req, res) => {
-    // You should store your Verify Token in an environment variable
-    const VERIFY_TOKEN = process.env.INSTAGRAM_WEBHOOK_VERIFY_TOKEN || 'creatoros-verify-token';
+    const VERIFY_TOKEN = process.env.INSTAGRAM_WEBHOOK_VERIFY_TOKEN;
+
+    if (!VERIFY_TOKEN) {
+        console.error('[Webhook] INSTAGRAM_WEBHOOK_VERIFY_TOKEN is not configured');
+        return res.sendStatus(500);
+    }
 
     const mode = req.query['hub.mode'];
     const token = req.query['hub.verify_token'];

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ const { getProfileFromCache, setProfileInCache } = require('./utils/profileCache
 const requiredEnvVars = [
     { name: 'MONGODB_URI', description: 'MongoDB connection string' },
     { name: 'JWT_SECRET', description: 'Secret key for JWT token signing' },
+    { name: 'INSTAGRAM_WEBHOOK_VERIFY_TOKEN', description: 'Instagram webhook verification token' },
+    { name: 'INSTAGRAM_APP_SECRET', description: 'Instagram app secret for webhook signature verification' },
 ];
 
 const missingVars = requiredEnvVars.filter((v) => !process.env[v.name]);


### PR DESCRIPTION
## Fix: Remove hardcoded Instagram webhook verification token fallback

Closes #490

### Problem
The `verifyWebhook` function in `controller/instagramWebhookController.js` used a hardcoded fallback token `'creatoros-verify-token'` when the `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` environment variable was not set. Since this is an open-source repository, any attacker could discover this default and subscribe their own webhook URL to receive DM events from creators using default configuration.

### Changes

**`controller/instagramWebhookController.js`**
- Removed the hardcoded fallback `|| 'creatoros-verify-token'` from the `VERIFY_TOKEN` assignment
- Added an early return with `500` status if `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` is not configured, with an error log for operators
- The endpoint now rejects verification attempts entirely when the env var is missing instead of accepting the known default

**`index.js`**
- Added `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` and `INSTAGRAM_APP_SECRET` to the required environment variable validation at startup, so the server warns early about missing webhook configuration

### Security Impact
- Eliminates the attack vector where an attacker could exploit the predictable fallback token to subscribe malicious webhooks
- Deployments missing the env var now fail-safe (500) instead of fail-open (accepting any token)