### PR TITLE
fix(auth): validate reset password length

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -19,6 +19,7 @@ const { isEmailTransportConfigured } = require("../utils/email");
 const CONTRIBUTOR_NAME = "Contributor";
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const VERIFICATION_TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MIN_PASSWORD_LENGTH = 8;
 const GUEST_CONTRIBUTOR_ROLE = "guest_contributor";
 const GENERIC_LOGIN_ERROR = "Invalid email or password";
 const GOOGLE_AUTH_CANCELLED_ERROR = "Google sign-in was cancelled or could not be completed.";
@@ -671,6 +672,13 @@ const resetPassword = asyncHandler(async (req, res) => {
 
     if (!token || !newPassword) {
         return res.status(400).json({ success: false, message: 'Token and password are required' });
+    }
+
+    if (typeof newPassword !== 'string' || newPassword.length < MIN_PASSWORD_LENGTH) {
+        return res.status(400).json({
+            success: false,
+            message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters`,
+        });
     }
 
     // Atomically claim the token: find a valid unused token and mark it used in one operation

--- a/tests/controllers/passwordReset.test.js
+++ b/tests/controllers/passwordReset.test.js
@@ -1,0 +1,75 @@
+jest.mock("../../connect", () => jest.fn().mockResolvedValue());
+jest.mock("../../model/user", () => ({
+  findById: jest.fn(),
+}));
+jest.mock("../../model/passwordResetToken", () => ({
+  findOneAndUpdate: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+const bcrypt = require("bcryptjs");
+const User = require("../../model/user");
+const PasswordResetToken = require("../../model/passwordResetToken");
+const { resetPassword } = require("../../controller/auth");
+
+describe("Password reset", () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      body: {
+        token: "reset-token",
+        newPassword: "NewPassword123!",
+      },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("rejects short reset passwords without consuming the token", async () => {
+    req.body.newPassword = "short";
+
+    await resetPassword(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Password must be at least 8 characters",
+    });
+    expect(PasswordResetToken.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(User.findById).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("resets the password when the token and new password are valid", async () => {
+    const user = {
+      email: "user@example.com",
+      save: jest.fn().mockResolvedValue(),
+    };
+    PasswordResetToken.findOneAndUpdate.mockResolvedValue({ userId: "user-id" });
+    User.findById.mockResolvedValue(user);
+    jest.spyOn(bcrypt, "hash").mockResolvedValue("hashed-password");
+
+    await resetPassword(req, res, next);
+
+    expect(PasswordResetToken.findOneAndUpdate).toHaveBeenCalledWith(
+      { token: "reset-token", used: false, expiresAt: { $gt: expect.any(Date) } },
+      { $set: { used: true, usedAt: expect.any(Date) } },
+      { new: true }
+    );
+    expect(user.password).toBe("hashed-password");
+    expect(user.passwordChangedAt).toBeInstanceOf(Date);
+    expect(user.save).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Password reset successfully. Please log in with your new password.",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- enforce the same minimum password length during password reset that signup already requires
- reject weak reset passwords before the reset token is claimed
- add regression coverage for short and valid reset-password requests

## Why

Password reset previously accepted any non-empty password, which allowed weaker credentials than the rest of the auth flow. Validating before token lookup also avoids consuming a valid reset token for an invalid password attempt.

Fixes #573

## Testing

- npm test -- tests/controllers/passwordReset.test.js --runInBand --forceExit
- npm run build