### PR TITLE
fix(billing): require signed stripe webhooks

### DIFF
--- a/controller/billing.js
+++ b/controller/billing.js
@@ -50,15 +50,22 @@ const createCheckoutSession = asyncHandler(async (req, res) => {
 // POST /api/billing/webhook
 const handleWebhook = asyncHandler(async (req, res) => {
     const sig = req.headers["stripe-signature"];
-    let event = req.body;
 
-    if (process.env.STRIPE_WEBHOOK_SECRET) {
-        try {
-            event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET);
-        } catch (err) {
-            console.error("Webhook Error:", err.message);
-            return res.status(400).send(`Webhook Error: ${err.message}`);
-        }
+    if (!stripe || !process.env.STRIPE_WEBHOOK_SECRET) {
+        console.error("Stripe webhook misconfigured: missing STRIPE_SECRET_KEY or STRIPE_WEBHOOK_SECRET");
+        return res.status(500).json({ success: false, message: "Billing webhook is not configured correctly" });
+    }
+
+    if (!sig) {
+        return res.status(400).send("Webhook Error: Missing Stripe signature");
+    }
+
+    let event;
+    try {
+        event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET);
+    } catch (err) {
+        console.error("Webhook Error:", err.message);
+        return res.status(400).send(`Webhook Error: ${err.message}`);
     }
 
     switch (event.type) {

--- a/tests/controllers/billingWebhook.test.js
+++ b/tests/controllers/billingWebhook.test.js
@@ -1,0 +1,92 @@
+jest.mock("../../model/user", () => ({
+  findByIdAndUpdate: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+function loadBillingController(stripeMock) {
+  jest.resetModules();
+  jest.doMock("../../model/user", () => ({
+    findByIdAndUpdate: jest.fn(),
+    findOne: jest.fn(),
+  }));
+  jest.doMock("stripe", () => jest.fn(() => stripeMock), { virtual: true });
+  return require("../../controller/billing");
+}
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    send: jest.fn(),
+  };
+}
+
+describe("Stripe billing webhook", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.clearAllMocks();
+  });
+
+  it("fails closed when the webhook secret is missing", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_123";
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    const stripeMock = {
+      webhooks: {
+        constructEvent: jest.fn(),
+      },
+    };
+    const { handleWebhook } = loadBillingController(stripeMock);
+    const res = createResponse();
+
+    await handleWebhook({ headers: {}, body: Buffer.from("{}") }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Billing webhook is not configured correctly",
+    });
+    expect(stripeMock.webhooks.constructEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests without a Stripe signature", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_123";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_123";
+    const stripeMock = {
+      webhooks: {
+        constructEvent: jest.fn(),
+      },
+    };
+    const { handleWebhook } = loadBillingController(stripeMock);
+    const res = createResponse();
+
+    await handleWebhook({ headers: {}, body: Buffer.from("{}") }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith("Webhook Error: Missing Stripe signature");
+    expect(stripeMock.webhooks.constructEvent).not.toHaveBeenCalled();
+  });
+
+  it("constructs the event from the signed raw body", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_123";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_123";
+    const stripeMock = {
+      webhooks: {
+        constructEvent: jest.fn().mockReturnValue({ type: "unknown.event" }),
+      },
+    };
+    const { handleWebhook } = loadBillingController(stripeMock);
+    const res = createResponse();
+    const body = Buffer.from("{}");
+
+    await handleWebhook(
+      { headers: { "stripe-signature": "sig_123" }, body },
+      res,
+      jest.fn()
+    );
+
+    expect(stripeMock.webhooks.constructEvent).toHaveBeenCalledWith(body, "sig_123", "whsec_123");
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+  });
+});


### PR DESCRIPTION
## Summary

- require Stripe webhook configuration before processing billing events
- reject webhook requests that do not include a Stripe signature
- verify all webhook payloads with Stripe before entering the event handler switch
- add focused regression coverage for misconfigured, unsigned, and signed webhook requests

## Why

The webhook endpoint previously processed request bodies directly when STRIPE_WEBHOOK_SECRET was missing. Billing webhooks are public endpoints and should fail closed when signatures cannot be verified.

Fixes #574

## Testing

- npm test -- tests/controllers/billingWebhook.test.js --runInBand --forceExit
- npm run build