### PR TITLE
fix(sponsors): scope crm records to jwt user id

### DIFF
--- a/controller/sponsor.js
+++ b/controller/sponsor.js
@@ -1,19 +1,41 @@
 const asyncHandler = require("../utils/asyncHandler");
 const Sponsor = require("../model/sponsor");
 
+function getAuthenticatedUserId(req) {
+    return req.user?.id || req.user?._id;
+}
+
+function requireAuthenticatedUserId(req, res) {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) {
+        res.status(401).json({ success: false, message: "Authentication required" });
+        return null;
+    }
+    return userId;
+}
+
 const getSponsors = asyncHandler(async (req, res) => {
-    const sponsors = await Sponsor.find({ creatorId: req.user._id }).sort({ createdAt: -1 });
+    const userId = requireAuthenticatedUserId(req, res);
+    if (!userId) return;
+
+    const sponsors = await Sponsor.find({ creatorId: userId }).sort({ createdAt: -1 });
     res.json({ success: true, data: sponsors });
 });
 
 const createSponsor = asyncHandler(async (req, res) => {
-    const sponsor = await Sponsor.create({ ...req.body, creatorId: req.user._id });
+    const userId = requireAuthenticatedUserId(req, res);
+    if (!userId) return;
+
+    const sponsor = await Sponsor.create({ ...req.body, creatorId: userId });
     res.status(201).json({ success: true, data: sponsor });
 });
 
 const updateSponsor = asyncHandler(async (req, res) => {
+    const userId = requireAuthenticatedUserId(req, res);
+    if (!userId) return;
+
     const sponsor = await Sponsor.findOneAndUpdate(
-        { _id: req.params.id, creatorId: req.user._id },
+        { _id: req.params.id, creatorId: userId },
         req.body,
         { new: true, runValidators: true }
     );
@@ -22,7 +44,10 @@ const updateSponsor = asyncHandler(async (req, res) => {
 });
 
 const deleteSponsor = asyncHandler(async (req, res) => {
-    const sponsor = await Sponsor.findOneAndDelete({ _id: req.params.id, creatorId: req.user._id });
+    const userId = requireAuthenticatedUserId(req, res);
+    if (!userId) return;
+
+    const sponsor = await Sponsor.findOneAndDelete({ _id: req.params.id, creatorId: userId });
     if (!sponsor) return res.status(404).json({ success: false, message: "Sponsor not found" });
     res.json({ success: true, message: "Sponsor deleted" });
 });

--- a/tests/controllers/sponsor.test.js
+++ b/tests/controllers/sponsor.test.js
@@ -1,0 +1,95 @@
+jest.mock("../../model/sponsor", () => ({
+  find: jest.fn(),
+  create: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  findOneAndDelete: jest.fn(),
+}));
+
+const Sponsor = require("../../model/sponsor");
+const {
+  getSponsors,
+  createSponsor,
+  updateSponsor,
+  deleteSponsor,
+} = require("../../controller/sponsor");
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+describe("Sponsor controller ownership", () => {
+  const userId = "64b7f1f1f1f1f1f1f1f1f1f1";
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      user: { id: userId },
+      params: { id: "sponsor-id" },
+      body: { companyName: "Acme" },
+    };
+    res = createResponse();
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("lists sponsors for the JWT user id", async () => {
+    const sort = jest.fn().mockResolvedValue([{ companyName: "Acme" }]);
+    Sponsor.find.mockReturnValue({ sort });
+
+    await getSponsors(req, res, next);
+
+    expect(Sponsor.find).toHaveBeenCalledWith({ creatorId: userId });
+    expect(sort).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: [{ companyName: "Acme" }],
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("creates sponsors for the JWT user id", async () => {
+    Sponsor.create.mockResolvedValue({ companyName: "Acme", creatorId: userId });
+
+    await createSponsor(req, res, next);
+
+    expect(Sponsor.create).toHaveBeenCalledWith({ companyName: "Acme", creatorId: userId });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: { companyName: "Acme", creatorId: userId },
+    });
+  });
+
+  it("updates sponsors using the JWT user id filter", async () => {
+    Sponsor.findOneAndUpdate.mockResolvedValue({ companyName: "Acme" });
+
+    await updateSponsor(req, res, next);
+
+    expect(Sponsor.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: "sponsor-id", creatorId: userId },
+      { companyName: "Acme" },
+      { new: true, runValidators: true }
+    );
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: { companyName: "Acme" },
+    });
+  });
+
+  it("deletes sponsors using the JWT user id filter", async () => {
+    Sponsor.findOneAndDelete.mockResolvedValue({ _id: "sponsor-id" });
+
+    await deleteSponsor(req, res, next);
+
+    expect(Sponsor.findOneAndDelete).toHaveBeenCalledWith({
+      _id: "sponsor-id",
+      creatorId: userId,
+    });
+    expect(res.json).toHaveBeenCalledWith({ success: true, message: "Sponsor deleted" });
+  });
+});


### PR DESCRIPTION
## Summary

- resolve sponsor ownership from req.user.id or req.user._id
- fail sponsor handlers clearly when no authenticated user id is present
- add controller coverage for list, create, update, and delete ownership filters

## Why

The sponsor CRM controller used req.user._id, but JWT sessions expose req.user.id. That made sponsor queries and writes lose their authenticated owner scope.

Fixes #576

## Testing

- npm test -- tests/controllers/sponsor.test.js --runInBand --forceExit
- npm run build