### PR TITLE
perf(content): paginate scheduled content

### DIFF
--- a/controller/contentController.js
+++ b/controller/contentController.js
@@ -2,6 +2,16 @@ const mongoose = require('mongoose');
 const asyncHandler = require('../utils/asyncHandler');
 const ScheduledContent = require('../model/scheduledContent');
 
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+const VALID_STATUSES = new Set(['scheduled', 'published', 'cancelled']);
+
+function parseListLimit(value) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIST_LIMIT;
+    return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
 /**
  * @function scheduleContent
  * @description Creates a piece of content scheduled to auto-publish at a future UTC time.
@@ -53,11 +63,57 @@ const scheduleContent = asyncHandler(async (req, res) => {
  * @returns {Promise<void>}
  */
 const listScheduledContent = asyncHandler(async (req, res) => {
-    const items = await ScheduledContent.find({ userId: req.user.id })
-        .sort({ scheduledAt: -1 })
+    const limit = parseListLimit(req.query?.limit);
+    const { status, cursor } = req.query || {};
+
+    if (status && !VALID_STATUSES.has(status)) {
+        return res.status(400).json({ success: false, message: 'Invalid status filter' });
+    }
+
+    if (cursor && !mongoose.Types.ObjectId.isValid(cursor)) {
+        return res.status(400).json({ success: false, message: 'Invalid cursor' });
+    }
+
+    let cursorItem = null;
+    if (cursor) {
+        cursorItem = await ScheduledContent.findOne({ _id: cursor, userId: req.user.id })
+            .select('scheduledAt')
+            .lean();
+
+        if (!cursorItem) {
+            return res.status(400).json({ success: false, message: 'Invalid cursor' });
+        }
+    }
+
+    const query = {
+        userId: req.user.id,
+        ...(status && { status }),
+        ...(cursorItem && {
+            $or: [
+                { scheduledAt: { $lt: cursorItem.scheduledAt } },
+                { scheduledAt: cursorItem.scheduledAt, _id: { $lt: cursor } },
+            ],
+        }),
+    };
+
+    const results = await ScheduledContent.find(query)
+        .sort({ scheduledAt: -1, _id: -1 })
+        .limit(limit + 1)
         .lean();
 
-    return res.json({ success: true, items });
+    const hasMore = results.length > limit;
+    const items = hasMore ? results.slice(0, limit) : results;
+    const nextCursor = hasMore ? items[items.length - 1]?._id?.toString() || null : null;
+
+    return res.json({
+        success: true,
+        items,
+        pagination: {
+            limit,
+            hasMore,
+            nextCursor,
+        },
+    });
 });
 
 /**

--- a/tests/controllers/contentController.test.js
+++ b/tests/controllers/contentController.test.js
@@ -1,0 +1,120 @@
+jest.mock("../../model/scheduledContent", () => ({
+  create: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+const ScheduledContent = require("../../model/scheduledContent");
+const { listScheduledContent } = require("../../controller/contentController");
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+function mockFindChain(results) {
+  const lean = jest.fn().mockResolvedValue(results);
+  const limit = jest.fn().mockReturnValue({ lean });
+  const sort = jest.fn().mockReturnValue({ limit });
+  ScheduledContent.find.mockReturnValue({ sort });
+  return { sort, limit, lean };
+}
+
+function mockFindOneChain(result) {
+  const lean = jest.fn().mockResolvedValue(result);
+  const select = jest.fn().mockReturnValue({ lean });
+  ScheduledContent.findOne.mockReturnValue({ select });
+  return { select, lean };
+}
+
+describe("Scheduled content listing", () => {
+  const userId = "64b7f1f1f1f1f1f1f1f1f1f1";
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      user: { id: userId },
+      query: {},
+    };
+    res = createResponse();
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("returns a bounded first page with pagination metadata", async () => {
+    const items = Array.from({ length: 21 }, (_, index) => ({
+      _id: `64b7f1f1f1f1f1f1f1f1f1${String(index).padStart(2, "0")}`.slice(0, 24),
+      caption: `Post ${index}`,
+    }));
+    const { sort, limit } = mockFindChain(items);
+
+    await listScheduledContent(req, res, next);
+
+    expect(ScheduledContent.find).toHaveBeenCalledWith({ userId });
+    expect(sort).toHaveBeenCalledWith({ scheduledAt: -1, _id: -1 });
+    expect(limit).toHaveBeenCalledWith(21);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      items: items.slice(0, 20),
+      pagination: {
+        limit: 20,
+        hasMore: true,
+        nextCursor: items[19]._id,
+      },
+    });
+  });
+
+  it("rejects an invalid status filter", async () => {
+    req.query.status = "draft";
+
+    await listScheduledContent(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: "Invalid status filter" });
+    expect(ScheduledContent.find).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed cursor", async () => {
+    req.query.cursor = "bad-cursor";
+
+    await listScheduledContent(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: "Invalid cursor" });
+    expect(ScheduledContent.find).not.toHaveBeenCalled();
+  });
+
+  it("continues from a valid cursor in scheduledAt order", async () => {
+    const cursor = "64b7f1f1f1f1f1f1f1f1f1f1";
+    const scheduledAt = new Date("2026-08-01T10:00:00.000Z");
+    req.query = { cursor, status: "scheduled", limit: "5" };
+    mockFindOneChain({ _id: cursor, scheduledAt });
+    const { limit } = mockFindChain([]);
+
+    await listScheduledContent(req, res, next);
+
+    expect(ScheduledContent.findOne).toHaveBeenCalledWith({ _id: cursor, userId });
+    expect(ScheduledContent.find).toHaveBeenCalledWith({
+      userId,
+      status: "scheduled",
+      $or: [
+        { scheduledAt: { $lt: scheduledAt } },
+        { scheduledAt, _id: { $lt: cursor } },
+      ],
+    });
+    expect(limit).toHaveBeenCalledWith(6);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      items: [],
+      pagination: {
+        limit: 5,
+        hasMore: false,
+        nextCursor: null,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add bounded pagination to scheduled content listing
- support status filters and cursor validation
- keep pagination aligned with scheduledAt and _id sort order
- add controller coverage for default pages, invalid filters, bad cursors, and valid cursor queries

## Why

The scheduled content endpoint loaded the full content history for a user in one response. Pagination keeps the endpoint responsive as creators accumulate more scheduled and published content.

Fixes #578

## Testing

- npm test -- tests/controllers/contentController.test.js --runInBand --forceExit
- npm run build