### PR TITLE
fix(bio): validate profile save payloads

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,12 +540,18 @@ app.get('/bio', protect, asyncHandler(async (req, res) => {
 // Save bio data
 app.post('/bio/save', protect, asyncHandler(async (req, res) => {
     const BioProfile = require('./model/bioProfile');
+    const { validateBioProfileInput } = require('./utils/bioProfileValidation');
     const userDoc = await User.findById(req.user.id);
     if (!userDoc) {
         return res.status(404).json({ success: false, message: 'User not found' });
     }
     
-    const { handle, name, bio, tags, avatarUrl, links } = req.body;
+    const validation = validateBioProfileInput(req.body);
+    if (!validation.success) {
+        return res.status(400).json({ success: false, message: validation.message });
+    }
+
+    const { handle, name, bio, tags, avatarUrl, links } = validation.data;
     const userHandle = handle || userDoc.alias;
     
     if (!userHandle) {

--- a/tests/utils/bioProfileValidation.test.js
+++ b/tests/utils/bioProfileValidation.test.js
@@ -1,0 +1,87 @@
+const { validateBioProfileInput, MAX_LINKS, MAX_TAGS } = require("../../utils/bioProfileValidation");
+
+describe("bio profile payload validation", () => {
+  it("normalizes a valid bio profile payload", () => {
+    const result = validateBioProfileInput({
+      handle: " creator_123 ",
+      name: " Creator ",
+      bio: "Useful links",
+      tags: [" resources "],
+      avatarUrl: " https://example.com/avatar.png ",
+      links: [
+        {
+          type: " resource ",
+          label: " Free guide ",
+          url: " https://example.com/guide ",
+          icon: " book ",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      handle: "creator_123",
+      name: "Creator",
+      bio: "Useful links",
+      tags: ["resources"],
+      avatarUrl: "https://example.com/avatar.png",
+      links: [
+        {
+          type: "resource",
+          label: "Free guide",
+          url: "https://example.com/guide",
+          icon: "book",
+        },
+      ],
+    });
+  });
+
+  it("rejects invalid handles", () => {
+    const result = validateBioProfileInput({ handle: "no spaces allowed" });
+
+    expect(result).toEqual({
+      success: false,
+      message: "Handle must be 3-50 characters and contain only letters, numbers, hyphens, or underscores",
+    });
+  });
+
+  it("rejects non-http avatar URLs", () => {
+    const result = validateBioProfileInput({ avatarUrl: "javascript:alert(1)" });
+
+    expect(result).toEqual({
+      success: false,
+      message: "Avatar URL must be a valid HTTP or HTTPS URL",
+    });
+  });
+
+  it("rejects too many tags", () => {
+    const result = validateBioProfileInput({
+      tags: Array.from({ length: MAX_TAGS + 1 }, (_, index) => `tag-${index}`),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      message: `Tags must be an array of up to ${MAX_TAGS} non-empty strings`,
+    });
+  });
+
+  it("rejects invalid links and oversized link arrays", () => {
+    expect(validateBioProfileInput({
+      links: [{ type: "resource", label: "Guide", url: "ftp://example.com/file" }],
+    })).toEqual({
+      success: false,
+      message: `Links must be an array of up to ${MAX_LINKS} valid HTTP or HTTPS links`,
+    });
+
+    expect(validateBioProfileInput({
+      links: Array.from({ length: MAX_LINKS + 1 }, () => ({
+        type: "resource",
+        label: "Guide",
+        url: "https://example.com/guide",
+      })),
+    })).toEqual({
+      success: false,
+      message: `Links must be an array of up to ${MAX_LINKS} valid HTTP or HTTPS links`,
+    });
+  });
+});

--- a/utils/bioProfileValidation.js
+++ b/utils/bioProfileValidation.js
@@ -1,0 +1,110 @@
+const { isValidUrl } = require('./validators');
+
+const HANDLE_PATTERN = /^[a-zA-Z0-9_-]{3,50}$/;
+const MAX_TAGS = 10;
+const MAX_LINKS = 25;
+
+function isOptionalHttpUrl(value) {
+    return !value || (typeof value === 'string' && isValidUrl(value.trim()));
+}
+
+function validateHandle(handle) {
+    if (!handle) return true;
+    return typeof handle === 'string' && HANDLE_PATTERN.test(handle.trim());
+}
+
+function normalizeTags(tags) {
+    if (tags === undefined) return [];
+    if (!Array.isArray(tags) || tags.length > MAX_TAGS) {
+        return null;
+    }
+
+    const normalized = [];
+    for (const tag of tags) {
+        if (typeof tag !== 'string') return null;
+        const value = tag.trim();
+        if (!value || value.length > 30) return null;
+        normalized.push(value);
+    }
+    return normalized;
+}
+
+function normalizeLinks(links) {
+    if (links === undefined) return [];
+    if (!Array.isArray(links) || links.length > MAX_LINKS) {
+        return null;
+    }
+
+    const normalized = [];
+    for (const link of links) {
+        if (!link || typeof link !== 'object') return null;
+
+        const type = typeof link.type === 'string' ? link.type.trim() : '';
+        const label = typeof link.label === 'string' ? link.label.trim() : '';
+        const url = typeof link.url === 'string' ? link.url.trim() : '';
+        const icon = typeof link.icon === 'string' ? link.icon.trim() : undefined;
+        const category = typeof link.category === 'string' ? link.category.trim() : undefined;
+
+        if (!type || type.length > 40 || !label || label.length > 80 || !isValidUrl(url.trim())) {
+            return null;
+        }
+
+        normalized.push({
+            type,
+            label,
+            url,
+            ...(icon && { icon }),
+            ...(category && { category }),
+            ...(link._id && { _id: link._id }),
+        });
+    }
+    return normalized;
+}
+
+function validateBioProfileInput(body = {}) {
+    const { handle, name, bio, tags, avatarUrl, links } = body;
+
+    if (!validateHandle(handle)) {
+        return { success: false, message: 'Handle must be 3-50 characters and contain only letters, numbers, hyphens, or underscores' };
+    }
+
+    if (name !== undefined && (typeof name !== 'string' || !name.trim() || name.trim().length > 100)) {
+        return { success: false, message: 'Name must be 1-100 characters' };
+    }
+
+    if (bio !== undefined && (typeof bio !== 'string' || bio.length > 500)) {
+        return { success: false, message: 'Bio must be at most 500 characters' };
+    }
+
+    if (!isOptionalHttpUrl(avatarUrl)) {
+        return { success: false, message: 'Avatar URL must be a valid HTTP or HTTPS URL' };
+    }
+
+    const normalizedTags = normalizeTags(tags);
+    if (!normalizedTags) {
+        return { success: false, message: `Tags must be an array of up to ${MAX_TAGS} non-empty strings` };
+    }
+
+    const normalizedLinks = normalizeLinks(links);
+    if (!normalizedLinks) {
+        return { success: false, message: `Links must be an array of up to ${MAX_LINKS} valid HTTP or HTTPS links` };
+    }
+
+    return {
+        success: true,
+        data: {
+            handle: handle?.trim(),
+            name: name?.trim(),
+            bio,
+            tags: normalizedTags,
+            avatarUrl: avatarUrl?.trim(),
+            links: normalizedLinks,
+        },
+    };
+}
+
+module.exports = {
+    validateBioProfileInput,
+    MAX_TAGS,
+    MAX_LINKS,
+};


### PR DESCRIPTION
## Summary

- add validation and normalization for bio profile save payloads
- enforce handle, name, bio, tag, avatar URL, and link limits before saving
- require HTTP or HTTPS URLs for saved bio links and avatar URLs
- add focused utility coverage for valid and invalid payloads

## Why

The bio save route previously wrote request body fields directly into the profile document. Validating these inputs keeps malformed or unsafe link data out of persisted bio profiles.

Fixes #580

## Testing

- npm test -- tests/utils/bioProfileValidation.test.js --runInBand --forceExit
- npm run build