### PR TITLE
fix(url): ignore invalid visit coordinates

### DIFF
--- a/index.js
+++ b/index.js
@@ -736,6 +736,7 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
 // ── URL SHORTENER POST ──
 
 const { isValidUrl } = require('./utils/validators');
+const { parseVisitCoordinates } = require('./utils/visitTelemetry');
 
 const { handleGenerateShortUrlRender } = require('./controller/url');
 app.post('/services/url-shortener/shorten', protect, preventContributorWrites, urlShortenerLimiter, handleGenerateShortUrlRender);
@@ -768,14 +769,13 @@ app.post('/services/file-upload/upload', protect, preventContributorWrites, uplo
 
 app.get('/u/:shortId', asyncHandler(async (req, res) => {
     const shortId = req.params.shortId;
-    const x = req.query.x ? parseFloat(req.query.x) : null;
-    const y = req.query.y ? parseFloat(req.query.y) : null;
+    const coordinates = parseVisitCoordinates(req.query);
 
     try {
         const visitData = { timestamp: new Date(), source: 'direct' };
-        if (x !== null && y !== null) {
-            visitData.x = x;
-            visitData.y = y;
+        if (coordinates) {
+            visitData.x = coordinates.x;
+            visitData.y = coordinates.y;
         }
         
         const entry = await Url.findOneAndUpdate(

--- a/tests/utils/visitTelemetry.test.js
+++ b/tests/utils/visitTelemetry.test.js
@@ -1,0 +1,19 @@
+const { parseVisitCoordinates } = require("../../utils/visitTelemetry");
+
+describe("visit telemetry coordinates", () => {
+  it("returns finite coordinates when both query values are valid numbers", () => {
+    expect(parseVisitCoordinates({ x: "12.5", y: "3" })).toEqual({ x: 12.5, y: 3 });
+  });
+
+  it("ignores coordinates when either value is missing", () => {
+    expect(parseVisitCoordinates({ x: "12.5" })).toBeNull();
+    expect(parseVisitCoordinates({ y: "3" })).toBeNull();
+  });
+
+  it("ignores NaN and infinite coordinates", () => {
+    expect(parseVisitCoordinates({ x: "abc", y: "3" })).toBeNull();
+    expect(parseVisitCoordinates({ x: "NaN", y: "3" })).toBeNull();
+    expect(parseVisitCoordinates({ x: "Infinity", y: "3" })).toBeNull();
+    expect(parseVisitCoordinates({ x: "3", y: "-Infinity" })).toBeNull();
+  });
+});

--- a/utils/visitTelemetry.js
+++ b/utils/visitTelemetry.js
@@ -1,0 +1,20 @@
+function parseFiniteNumber(value) {
+    if (value === undefined || value === null || value === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseVisitCoordinates(query = {}) {
+    const x = parseFiniteNumber(query.x);
+    const y = parseFiniteNumber(query.y);
+
+    if (x === null || y === null) {
+        return null;
+    }
+
+    return { x, y };
+}
+
+module.exports = {
+    parseVisitCoordinates,
+};


### PR DESCRIPTION
## Summary

- parse redirect telemetry coordinates with finite number checks
- avoid storing NaN or infinite x/y values in visit history
- add utility coverage for valid, missing, NaN, and infinite coordinate inputs

## Why

The redirect route previously used parseFloat and stored coordinates whenever query params were present. Invalid values could become NaN or Infinity in persisted visit telemetry.

Fixes #581

## Testing

- npm test -- tests/utils/visitTelemetry.test.js --runInBand --forceExit
- npm run build