### PR TITLE
enhance(url): paginate link list api

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -5,6 +5,15 @@ const Url = require('../model/url');
 const { isValidUrl } = require('../utils/validators');
 const asyncHandler = require('../utils/asyncHandler');
 
+const DEFAULT_LINK_LIST_LIMIT = 20;
+const MAX_LINK_LIST_LIMIT = 100;
+
+function parseListLimit(value) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LINK_LIST_LIMIT;
+    return Math.min(parsed, MAX_LINK_LIST_LIMIT);
+}
+
 /**
  * @function deriveTitle
  * @description Extracts or derives a meaningful title from a given URL.
@@ -142,10 +151,14 @@ async function handleGenerateShortURL(req, res) {
 async function handleListUserLinks(req, res) {
     const hostBase = `${req.protocol}://${req.get('host')}`;
     const userId = req.user?.id;
+    const limit = parseListLimit(req.query?.limit);
+    const cursor = req.query?.cursor || null;
 
-    const entries = await Url.listForUser(userId, 100);
+    const entries = await Url.listForUser(userId, { limit: limit + 1, cursor });
+    const hasMore = entries.length > limit;
+    const pageEntries = hasMore ? entries.slice(0, limit) : entries;
 
-    const links = entries.map((entry) => serializeLink(entry, hostBase));
+    const links = pageEntries.map((entry) => serializeLink(entry, hostBase));
     const totalClicks = links.reduce((sum, link) => sum + link.totalClicks, 0);
     const topLink = links.reduce(
         (best, link) => (link.totalClicks > (best?.totalClicks || 0) ? link : best),
@@ -162,6 +175,11 @@ async function handleListUserLinks(req, res) {
             topLinkClicks: topLink?.clicksLabel || '0',
         },
         domain: hostBase.replace(/^https?:\/\//, ''),
+        pagination: {
+            limit,
+            hasMore,
+            nextCursor: hasMore ? pageEntries[pageEntries.length - 1]?._id?.toString?.() || null : null,
+        },
     });
 }
 

--- a/model/url.js
+++ b/model/url.js
@@ -60,9 +60,26 @@ const urlSchema = new mongoose.Schema({
     ],
 });
 
-urlSchema.statics.listForUser = async function (userId, limit = 100) {
-    return this.find({ userId })
-        .sort({ createdAt: -1 })
+urlSchema.statics.listForUser = async function (userId, options = {}) {
+    const limit = typeof options === "number" ? options : options.limit || 100;
+    const cursor = typeof options === "object" ? options.cursor : null;
+    const query = { userId };
+
+    if (cursor) {
+        const cursorLink = await this.findOne({ _id: cursor, userId })
+            .select("createdAt")
+            .lean();
+
+        if (!cursorLink) return [];
+
+        query.$or = [
+            { createdAt: { $lt: cursorLink.createdAt } },
+            { createdAt: cursorLink.createdAt, _id: { $lt: cursor } },
+        ];
+    }
+
+    return this.find(query)
+        .sort({ createdAt: -1, _id: -1 })
         .limit(limit)
         .lean();
 };
@@ -72,6 +89,7 @@ const mockUrls = [];
 
 class MockUrlModel {
     constructor(data) {
+        this._id = data._id || new mongoose.Types.ObjectId();
         this.shortId = data.shortId;
         this.redirectUrl = data.redirectUrl;
         this.campaignName = data.campaignName || "Untitled Campaign";
@@ -153,10 +171,23 @@ class MockUrlModel {
         return { deletedCount: count };
     }
 
-    static async listForUser(userId, limit = 100) {
+    static async listForUser(userId, options = {}) {
+        const limit = typeof options === "number" ? options : options.limit || 100;
+        const cursor = typeof options === "object" ? options.cursor : null;
         let results = mockUrls.filter(u => u.userId?.toString() === userId?.toString());
+        if (cursor) {
+            const cursorIndex = results.findIndex(u => u._id?.toString() === cursor?.toString() || u.shortId === cursor);
+            if (cursorIndex === -1) return [];
+            const cursorItem = results[cursorIndex];
+            results = results.filter((u) => {
+                const createdDiff = new Date(u.createdAt) - new Date(cursorItem.createdAt);
+                if (createdDiff < 0) return true;
+                if (createdDiff > 0) return false;
+                return (u._id?.toString() || u.shortId) < (cursorItem._id?.toString() || cursorItem.shortId);
+            });
+        }
         return results
-            .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+            .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt) || String(b._id || b.shortId).localeCompare(String(a._id || a.shortId)))
             .slice(0, limit)
             .map((u) => new MockUrlModel(u));
     }

--- a/tests/controllers/urlList.test.js
+++ b/tests/controllers/urlList.test.js
@@ -1,0 +1,73 @@
+jest.mock("../../model/url", () => ({
+  listForUser: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+const Url = require("../../model/url");
+const { handleListUserLinks } = require("../../controller/url");
+
+function createResponse() {
+  return {
+    json: jest.fn(),
+  };
+}
+
+function createRequest(query = {}) {
+  return {
+    protocol: "https",
+    query,
+    user: { id: "user-id" },
+    get: jest.fn().mockReturnValue("creatoros.test"),
+  };
+}
+
+describe("URL list API pagination", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the first page with pagination metadata", async () => {
+    const entries = Array.from({ length: 21 }, (_, index) => ({
+      _id: { toString: () => `cursor-${index}` },
+      shortId: `link-${index}`,
+      redirectUrl: `https://example.com/${index}`,
+      totalClicks: index,
+      createdAt: new Date("2026-07-22T00:00:00.000Z"),
+    }));
+    Url.listForUser.mockResolvedValue(entries);
+    const res = createResponse();
+
+    await handleListUserLinks(createRequest(), res);
+
+    expect(Url.listForUser).toHaveBeenCalledWith("user-id", { limit: 21, cursor: null });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      links: expect.arrayContaining([
+        expect.objectContaining({ shortId: "link-0" }),
+      ]),
+      pagination: {
+        limit: 20,
+        hasMore: true,
+        nextCursor: "cursor-19",
+      },
+    }));
+    expect(res.json.mock.calls[0][0].links).toHaveLength(20);
+  });
+
+  it("clamps large limits to the maximum page size", async () => {
+    Url.listForUser.mockResolvedValue([]);
+    const res = createResponse();
+
+    await handleListUserLinks(createRequest({ limit: "500", cursor: "cursor-1" }), res);
+
+    expect(Url.listForUser).toHaveBeenCalledWith("user-id", { limit: 101, cursor: "cursor-1" });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      pagination: {
+        limit: 100,
+        hasMore: false,
+        nextCursor: null,
+      },
+    }));
+  });
+});


### PR DESCRIPTION
## Summary

- add limit and cursor support to the URL list API
- return pagination metadata alongside existing links, stats, and domain fields
- update Url.listForUser to fetch cursor windows in createdAt order
- add controller coverage for default pagination and max-limit clamping

## Why

The URL list API previously returned only the latest 100 links with no way to retrieve older records. Pagination lets clients load the full link history over multiple requests without unbounded responses.

Fixes #582

## Testing

- npm test -- tests/controllers/urlList.test.js --runInBand --forceExit
- npm run build