### PR TITLE
fix: remove duplicate route and add wantsHtml check in auth middleware

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -48,7 +48,12 @@ const protect = async (req, res, next) => {
             const user = await User.findOne({ email: decoded.email });
 
             if (!user) {
-                return res.redirect("/login");
+                if (wantsHtml(req)) return res.redirect("/login");
+                return res.status(401).json({
+                    success: false,
+                    message: "Invalid session",
+                    error: "Invalid session",
+                });
             }
 
             // Check if password was changed after token was issued

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -397,20 +397,6 @@ router.get("/reset-password", (req, res) => {
 /**
  * @swagger
  * /reset-password:
- *   get:
- *     summary: GET request for /reset-password
- *     description: Renders the password reset page.
- *     responses:
- *       200:
- *         description: Successful response
- */
-router.get("/reset-password", (req, res) => {
-    res.render("reset-password", { token: req.query.token, error: null });
-});
-
-/**
- * @swagger
- * /reset-password:
  *   post:
  *     summary: Reset password with token
  *     description: Validates reset token and updates user password. Token can only be used once.


### PR DESCRIPTION
## Bugs Fixed

1. Duplicate GET /reset-password route in routes/auth.js
2. Missing wantsHtml check before redirect in middleware/auth.js