### PR TITLE
fix(auth): remove duplicate reset route

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -397,20 +397,6 @@ router.get("/reset-password", (req, res) => {
 /**
  * @swagger
  * /reset-password:
- *   get:
- *     summary: GET request for /reset-password
- *     description: Renders the password reset page.
- *     responses:
- *       200:
- *         description: Successful response
- */
-router.get("/reset-password", (req, res) => {
-    res.render("reset-password", { token: req.query.token, error: null });
-});
-
-/**
- * @swagger
- * /reset-password:
  *   post:
  *     summary: Reset password with token
  *     description: Validates reset token and updates user password. Token can only be used once.

--- a/tests/routes/authRoutes.test.js
+++ b/tests/routes/authRoutes.test.js
@@ -1,0 +1,57 @@
+const express = require("express");
+const request = require("supertest");
+
+jest.mock("passport", () => ({
+  use: jest.fn(),
+  authenticate: jest.fn(() => (req, res, next) => next()),
+}));
+
+jest.mock("../../controller/auth", () => ({
+  signup: jest.fn(),
+  login: jest.fn(),
+  handleGoogleCallback: jest.fn(),
+  loginAsContributor: jest.fn(),
+  verifyEmail: jest.fn(),
+  resendVerificationEmail: jest.fn(),
+  requestPasswordReset: jest.fn(),
+  resetPassword: jest.fn(),
+}));
+
+jest.mock("../../middleware/validators", () => ({
+  signupValidator: (req, res, next) => next(),
+  loginValidator: (req, res, next) => next(),
+  resendVerificationValidator: (req, res, next) => next(),
+}));
+
+jest.mock("../../middleware/rateLimiters", () => ({
+  loginLimiter: (req, res, next) => next(),
+  signupLimiter: (req, res, next) => next(),
+  emailVerificationLimiter: (req, res, next) => next(),
+  forgotPasswordLimiter: (req, res, next) => next(),
+}));
+
+jest.mock("../../connect", () => jest.fn());
+
+const authRoutes = require("../../routes/auth");
+
+function createApp() {
+  const app = express();
+  app.set("view engine", "ejs");
+  app.response.render = function render(view, locals) {
+    return this.status(200).json({ view, locals });
+  };
+  app.use(authRoutes);
+  return app;
+}
+
+describe("auth routes", () => {
+  it("renders reset password once with the query token", async () => {
+    const res = await request(createApp()).get("/reset-password?token=abc123");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      view: "reset-password",
+      locals: { token: "abc123", error: null },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- remove the duplicate GET /reset-password route registration
- keep the existing reset-password render behavior
- add route coverage for passing the token query value to the view

## Why

The same GET /reset-password handler was registered twice. Keeping a single route avoids dead code and prevents future maintenance drift.

Fixes #603

## Testing

- npm test -- tests/routes/authRoutes.test.js --runInBand --forceExit
- npm run build