### PR TITLE
fix(auth): rate limit password resets

### DIFF
--- a/middleware/rateLimiters.js
+++ b/middleware/rateLimiters.js
@@ -90,6 +90,15 @@ const forgotPasswordLimiter = rateLimit({
     }
 });
 
+const resetPasswordLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 5,
+    handler: (req, res) => {
+        const message = 'Too many password reset attempts. Please try again later.';
+        return res.status(429).json({ success: false, message, error: message });
+    }
+});
+
 
 
 function keyByUserOrIp(req) {
@@ -140,5 +149,6 @@ module.exports = {
     emailVerificationLimiter,
     aiGenerationLimiter,
     instagramProfileLimiter,
-    forgotPasswordLimiter
+    forgotPasswordLimiter,
+    resetPasswordLimiter
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,7 +4,7 @@ const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const { signup, login, handleGoogleCallback, loginAsContributor, verifyEmail, resendVerificationEmail, requestPasswordReset, resetPassword } = require("../controller/auth");
 const { signupValidator, loginValidator, resendVerificationValidator } = require("../middleware/validators");
 const connectDB = require("../connect");
-const { loginLimiter, signupLimiter, emailVerificationLimiter, forgotPasswordLimiter } = require("../middleware/rateLimiters");
+const { loginLimiter, signupLimiter, emailVerificationLimiter, forgotPasswordLimiter, resetPasswordLimiter } = require("../middleware/rateLimiters");
 
 const router = express.Router();
 
@@ -431,6 +431,6 @@ router.get("/reset-password", (req, res) => {
  *       400:
  *         description: Invalid, expired, or already used token
  */
-router.post("/reset-password", resetPassword);
+router.post("/reset-password", resetPasswordLimiter, resetPassword);
 
 module.exports = router;

--- a/tests/routes/resetPasswordLimiter.test.js
+++ b/tests/routes/resetPasswordLimiter.test.js
@@ -1,0 +1,65 @@
+const express = require("express");
+const request = require("supertest");
+
+const mockResetPassword = jest.fn((req, res) => res.json({ success: true }));
+const mockResetPasswordLimiter = jest.fn((req, res, next) => next());
+
+jest.mock("passport", () => ({
+  use: jest.fn(),
+  authenticate: jest.fn(() => (req, res, next) => next()),
+}));
+
+jest.mock("../../controller/auth", () => ({
+  signup: jest.fn(),
+  login: jest.fn(),
+  handleGoogleCallback: jest.fn(),
+  loginAsContributor: jest.fn(),
+  verifyEmail: jest.fn(),
+  resendVerificationEmail: jest.fn(),
+  requestPasswordReset: jest.fn(),
+  resetPassword: mockResetPassword,
+}));
+
+jest.mock("../../middleware/validators", () => ({
+  signupValidator: (req, res, next) => next(),
+  loginValidator: (req, res, next) => next(),
+  resendVerificationValidator: (req, res, next) => next(),
+}));
+
+jest.mock("../../middleware/rateLimiters", () => ({
+  loginLimiter: (req, res, next) => next(),
+  signupLimiter: (req, res, next) => next(),
+  emailVerificationLimiter: (req, res, next) => next(),
+  forgotPasswordLimiter: (req, res, next) => next(),
+  resetPasswordLimiter: mockResetPasswordLimiter,
+}));
+
+jest.mock("../../connect", () => jest.fn());
+
+const authRoutes = require("../../routes/auth");
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(authRoutes);
+  return app;
+}
+
+describe("reset password route limiter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("runs the reset password limiter before the controller", async () => {
+    const res = await request(createApp())
+      .post("/reset-password")
+      .send({ token: "token", newPassword: "Password123!" });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockResetPasswordLimiter).toHaveBeenCalled();
+    expect(mockResetPassword).toHaveBeenCalled();
+    expect(mockResetPasswordLimiter.mock.invocationCallOrder[0]).toBeLessThan(
+      mockResetPassword.mock.invocationCallOrder[0]
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated limiter for reset-password submissions
- apply the limiter before the resetPassword controller
- add route coverage proving the limiter runs before reset work

## Why

The forgot-password request endpoint was throttled, but reset submissions were not. Applying a limiter before token lookup and hashing reduces abuse potential on the reset path.

Fixes #604

## Testing

- npm test -- tests/routes/resetPasswordLimiter.test.js --runInBand --forceExit
- npm run build