### PR TITLE
fix(email): read mail config dynamically

### DIFF
--- a/tests/utils/email.test.js
+++ b/tests/utils/email.test.js
@@ -1,0 +1,66 @@
+const mockCreateTransport = jest.fn();
+
+jest.mock("nodemailer", () => ({
+  createTransport: mockCreateTransport,
+}));
+
+const {
+  createTransporter,
+  isEmailTransportConfigured,
+} = require("../../utils/email");
+
+describe("email configuration", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    mockCreateTransport.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses current environment values when creating a transporter", () => {
+    delete process.env.EMAIL_USER;
+    delete process.env.EMAIL_PASSWORD;
+    delete process.env.EMAIL_SERVICE;
+
+    process.env.EMAIL_USER = "sender@example.com";
+    process.env.EMAIL_PASSWORD = "secret";
+    process.env.EMAIL_SERVICE = "smtp";
+
+    expect(isEmailTransportConfigured()).toBe(true);
+
+    createTransporter();
+
+    expect(mockCreateTransport).toHaveBeenCalledWith({
+      auth: {
+        user: "sender@example.com",
+        pass: "secret",
+      },
+      service: "smtp",
+    });
+  });
+
+  it("derives secure mode from the current port", () => {
+    process.env.EMAIL_USER = "sender@example.com";
+    process.env.EMAIL_PASSWORD = "secret";
+    process.env.EMAIL_HOST = "smtp.example.com";
+    process.env.EMAIL_PORT = "465";
+    delete process.env.EMAIL_SERVICE;
+    delete process.env.EMAIL_SECURE;
+
+    createTransporter();
+
+    expect(mockCreateTransport).toHaveBeenCalledWith({
+      auth: {
+        user: "sender@example.com",
+        pass: "secret",
+      },
+      host: "smtp.example.com",
+      port: 465,
+      secure: true,
+    });
+  });
+});

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,17 +1,5 @@
 const nodemailer = require('nodemailer');
 
-const {
-  EMAIL_SERVICE,
-  EMAIL_HOST,
-  EMAIL_PORT,
-  EMAIL_SECURE,
-  EMAIL_USER,
-  EMAIL_PASSWORD,
-  EMAIL_FROM_NAME,
-  EMAIL_FROM,
-  EMAIL_REPLY_TO,
-} = process.env;
-
 function escapeHtml(str) {
   if (!str) return '';
   return str
@@ -22,12 +10,47 @@ function escapeHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+function getEmailConfig() {
+  const {
+    EMAIL_SERVICE,
+    EMAIL_HOST,
+    EMAIL_PORT,
+    EMAIL_SECURE,
+    EMAIL_USER,
+    EMAIL_PASSWORD,
+    EMAIL_FROM_NAME,
+    EMAIL_FROM,
+    EMAIL_REPLY_TO,
+  } = process.env;
+
+  return {
+    EMAIL_SERVICE,
+    EMAIL_HOST,
+    EMAIL_PORT,
+    EMAIL_SECURE,
+    EMAIL_USER,
+    EMAIL_PASSWORD,
+    EMAIL_FROM_NAME,
+    EMAIL_FROM,
+    EMAIL_REPLY_TO,
+  };
+}
+
 /**
  * @function createTransporter
  * @description Creates a nodemailer transporter object for sending emails.
  * @returns {any}
  */
 function createTransporter() {
+  const {
+    EMAIL_SERVICE,
+    EMAIL_HOST,
+    EMAIL_PORT,
+    EMAIL_SECURE,
+    EMAIL_USER,
+    EMAIL_PASSWORD,
+  } = getEmailConfig();
+
   if (!EMAIL_USER || !EMAIL_PASSWORD) {
     throw new Error('Email transport is not configured. Set EMAIL_USER and EMAIL_PASSWORD.');
   }
@@ -88,6 +111,7 @@ function isEmailTransportConfigured() {
  */
 async function sendInvitationEmail({ to, inviterName, projectName, inviteUrl, personalMessage }) {
   const transporter = createTransporter();
+  const { EMAIL_USER, EMAIL_FROM_NAME, EMAIL_FROM, EMAIL_REPLY_TO } = getEmailConfig();
   const from = EMAIL_FROM || EMAIL_USER;
   const fromName = EMAIL_FROM_NAME || 'CreatorOS';
   const replyTo = EMAIL_REPLY_TO || from;
@@ -141,6 +165,7 @@ If the link does not work, paste it into your browser.`;
  */
 async function sendVerificationEmail({ to, verificationLink, userName }) {
   const transporter = createTransporter();
+  const { EMAIL_USER, EMAIL_FROM_NAME, EMAIL_FROM, EMAIL_REPLY_TO } = getEmailConfig();
   const from = EMAIL_FROM || EMAIL_USER;
   const fromName = EMAIL_FROM_NAME || 'CreatorOS';
   const replyTo = EMAIL_REPLY_TO || from;
@@ -186,6 +211,7 @@ CreatorOS Team`;
 
 async function sendPasswordResetEmail({ to, resetLink, userName }) {
   const transporter = createTransporter();
+  const { EMAIL_USER, EMAIL_FROM_NAME, EMAIL_FROM, EMAIL_REPLY_TO } = getEmailConfig();
   const from = EMAIL_FROM || EMAIL_USER;
   const fromName = EMAIL_FROM_NAME || 'CreatorOS';
   const replyTo = EMAIL_REPLY_TO || from;
@@ -232,6 +258,7 @@ CreatorOS Team`;
 
 async function sendDeletionConfirmationEmail({ to, confirmLink, userName, scheduledDate }) {
   const transporter = createTransporter();
+  const { EMAIL_USER, EMAIL_FROM_NAME, EMAIL_FROM, EMAIL_REPLY_TO } = getEmailConfig();
   const from = EMAIL_FROM || EMAIL_USER;
   const fromName = EMAIL_FROM_NAME || 'CreatorOS';
   const replyTo = EMAIL_REPLY_TO || from;
@@ -286,4 +313,5 @@ module.exports = {
   sendPasswordResetEmail,
   sendDeletionConfirmationEmail,
   isEmailTransportConfigured,
+  createTransporter,
 };


### PR DESCRIPTION
## Summary

- read email environment values when creating transporters and sending mail
- keep transport configuration aligned with isEmailTransportConfigured
- add tests for env values set after module import and secure port inference

## Why

The email module captured env vars at require time, while configuration checks read process.env dynamically. That could make checks pass while transporter creation still used stale empty values.

Fixes #605

## Testing

- npm test -- tests/utils/email.test.js --runInBand --forceExit
- npm run build