### PR TITLE
fix(collaboration): prevent duplicate pending invites

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -60,12 +60,32 @@ const sendCollaboratorInvite = asyncHandler(async (req, res, next) => {
   }
 
   const { email, projectName, message } = result.data;
+  const normalizedEmail = email.trim().toLowerCase();
+  const normalizedProjectName = projectName?.trim() || 'CreatorOS Collaboration';
+
+  const existingPendingInvite = await Invite.findOne({
+    inviter: req.user.id,
+    email: normalizedEmail,
+    projectName: normalizedProjectName,
+    status: 'pending',
+  });
+
+  if (existingPendingInvite) {
+    const userDoc = await User.findById(req.user.id).select('name email').lean();
+    const invites = await Invite.find({ inviter: req.user.id }).sort({ createdAt: -1 }).limit(12).lean();
+    return res.status(409).render('creator-crm', {
+      user: buildAccountViewModel(userDoc, req.user),
+      invites,
+      success: null,
+      error: `An invite is already pending for ${normalizedEmail}.`,
+    });
+  }
 
   const token = crypto.randomBytes(22).toString('hex');
   const invite = await Invite.create({
     inviter: req.user.id,
-    email: email.trim().toLowerCase(),
-    projectName: projectName?.trim() || 'CreatorOS Collaboration',
+    email: normalizedEmail,
+    projectName: normalizedProjectName,
     message: message?.trim(),
     token,
   });

--- a/tests/controllers/collaborationInvite.test.js
+++ b/tests/controllers/collaborationInvite.test.js
@@ -1,0 +1,74 @@
+jest.mock("../../model/invite", () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  findByIdAndDelete: jest.fn(),
+}));
+
+jest.mock("../../model/user", () => ({
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+}));
+
+jest.mock("../../utils/email", () => ({
+  sendInvitationEmail: jest.fn(),
+}));
+
+const Invite = require("../../model/invite");
+const User = require("../../model/user");
+const { sendInvitationEmail } = require("../../utils/email");
+const { sendCollaboratorInvite } = require("../../controller/collaborationController");
+
+function createQuery(result) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    render: jest.fn(),
+  };
+}
+
+describe("sendCollaboratorInvite", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    User.findById.mockReturnValue(createQuery({ name: "Creator", email: "creator@example.com" }));
+    Invite.find.mockReturnValue(createQuery([]));
+  });
+
+  it("does not create or send a duplicate pending invite", async () => {
+    Invite.findOne.mockResolvedValue({ _id: "invite-id", status: "pending" });
+    const req = {
+      user: { id: "user-id" },
+      protocol: "https",
+      get: jest.fn().mockReturnValue("creatoros.test"),
+      body: {
+        email: "Guest@Example.com",
+        projectName: " Launch ",
+      },
+    };
+    const res = createResponse();
+
+    await sendCollaboratorInvite(req, res, jest.fn());
+
+    expect(Invite.findOne).toHaveBeenCalledWith({
+      inviter: "user-id",
+      email: "guest@example.com",
+      projectName: "Launch",
+      status: "pending",
+    });
+    expect(Invite.create).not.toHaveBeenCalled();
+    expect(sendInvitationEmail).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.render).toHaveBeenCalledWith("creator-crm", expect.objectContaining({
+      success: null,
+      error: "An invite is already pending for guest@example.com.",
+    }));
+  });
+});


### PR DESCRIPTION
## Summary

- normalize invite email and project name before creating invites
- detect existing pending invites for the same inviter, email, and project
- return a clear duplicate message without creating another token or sending another email
- add focused controller coverage for the duplicate path

## Why

The invite flow previously created a new pending invite every time the form was submitted, allowing duplicate valid tokens and repeated emails for the same collaboration.

Fixes #606

## Testing

- npm test -- tests/controllers/collaborationInvite.test.js --runInBand --forceExit
- npm run build