### PR TITLE
fix(collaboration): report invite email mismatch

### DIFF
--- a/controller/collaborationController.js
+++ b/controller/collaborationController.js
@@ -204,6 +204,11 @@ const acceptInviteFromDashboard = asyncHandler(async (req, res, next) => {
       ) {
         return renderDashboard(req, res, { inviteAcceptError: "This invitation has expired." });
       }
+      if (existingInvite.email?.trim().toLowerCase() !== userDoc.email.trim().toLowerCase()) {
+        return renderDashboard(req, res, {
+          inviteAcceptError: 'This invitation was sent to a different email address.',
+        });
+      }
       return renderDashboard(req, res, { inviteAcceptMessage: 'This invitation has already been accepted.' });
     }
 

--- a/tests/controllers/inviteAccept.test.js
+++ b/tests/controllers/inviteAccept.test.js
@@ -1,0 +1,61 @@
+jest.mock("../../model/invite", () => ({
+  countDocuments: jest.fn().mockResolvedValue(0),
+  findOneAndUpdate: jest.fn(),
+  findOne: jest.fn(),
+}));
+
+jest.mock("../../model/user", () => ({
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+}));
+
+jest.mock("../../utils/dashboardHelper", () => ({
+  getDashboardData: jest.fn().mockResolvedValue({}),
+}));
+
+const Invite = require("../../model/invite");
+const User = require("../../model/user");
+const { acceptInviteFromDashboard } = require("../../controller/collaborationController");
+
+function createQuery(result) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function createResponse() {
+  return {
+    render: jest.fn(),
+  };
+}
+
+describe("acceptInviteFromDashboard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reports an email mismatch instead of already accepted", async () => {
+    User.findById.mockReturnValue(createQuery({ email: "signedin@example.com", name: "Signed In" }));
+    Invite.findOneAndUpdate.mockResolvedValue(null);
+    Invite.findOne.mockResolvedValue({
+      token: "invite-token",
+      status: "pending",
+      email: "recipient@example.com",
+      expiresAt: new Date(Date.now() + 60 * 1000),
+    });
+    const req = {
+      user: { id: "user-id", name: "Signed In" },
+      body: { inviteToken: "invite-token" },
+    };
+    const res = createResponse();
+
+    await acceptInviteFromDashboard(req, res, jest.fn());
+
+    expect(Invite.findOne).toHaveBeenCalledWith({ token: "invite-token" });
+    expect(res.render).toHaveBeenCalledWith("dashboard", expect.objectContaining({
+      inviteAcceptError: "This invitation was sent to a different email address.",
+      inviteAcceptMessage: null,
+    }));
+  });
+});


### PR DESCRIPTION
## Summary

- distinguish wrong-email invite acceptance from already-accepted invites
- show a clear dashboard error when the signed-in email does not match the invite recipient
- add focused controller coverage for the mismatch path

## Why

The invite accept fallback loaded an existing token but did not check whether it belonged to the signed-in user. Pending invites for another email could be reported as already accepted.

Fixes #607

## Testing

- npm test -- tests/controllers/inviteAccept.test.js --runInBand --forceExit
- npm run build