### PR TITLE
fix(content): validate scheduled media url

### DIFF
--- a/controller/contentController.js
+++ b/controller/contentController.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const asyncHandler = require('../utils/asyncHandler');
 const ScheduledContent = require('../model/scheduledContent');
+const { isValidUrl } = require('../utils/validators');
 
 /**
  * @function scheduleContent
@@ -33,10 +34,15 @@ const scheduleContent = asyncHandler(async (req, res) => {
         return res.status(400).json({ success: false, message: 'scheduledAt must be in the future' });
     }
 
+    const normalizedMediaUrl = typeof mediaUrl === 'string' ? mediaUrl.trim() : mediaUrl;
+    if (normalizedMediaUrl && (typeof normalizedMediaUrl !== 'string' || !isValidUrl(normalizedMediaUrl))) {
+        return res.status(400).json({ success: false, message: 'mediaUrl must be a valid HTTP or HTTPS URL' });
+    }
+
     const content = await ScheduledContent.create({
         userId: req.user.id,
         caption: caption.trim(),
-        mediaUrl: mediaUrl || undefined,
+        mediaUrl: normalizedMediaUrl || undefined,
         timezone: timezone || 'UTC',
         scheduledAt: scheduledDate,
         status: 'scheduled',

--- a/tests/controllers/scheduleContent.test.js
+++ b/tests/controllers/scheduleContent.test.js
@@ -1,0 +1,55 @@
+jest.mock("../../model/scheduledContent", () => ({
+  create: jest.fn(),
+}));
+
+const ScheduledContent = require("../../model/scheduledContent");
+const { scheduleContent } = require("../../controller/contentController");
+
+function createResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+}
+
+describe("scheduleContent mediaUrl validation", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      user: { id: "user-id" },
+      body: {
+        caption: "Launch post",
+        scheduledAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      },
+    };
+    res = createResponse();
+    jest.clearAllMocks();
+  });
+
+  it("rejects unsupported mediaUrl protocols", async () => {
+    req.body.mediaUrl = "javascript:alert(1)";
+
+    await scheduleContent(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "mediaUrl must be a valid HTTP or HTTPS URL",
+    });
+    expect(ScheduledContent.create).not.toHaveBeenCalled();
+  });
+
+  it("trims and saves valid HTTP mediaUrl values", async () => {
+    req.body.mediaUrl = " https://example.com/media.png ";
+    ScheduledContent.create.mockResolvedValue({ _id: "content-id" });
+
+    await scheduleContent(req, res, jest.fn());
+
+    expect(ScheduledContent.create).toHaveBeenCalledWith(expect.objectContaining({
+      mediaUrl: "https://example.com/media.png",
+    }));
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});


### PR DESCRIPTION
## Summary

- validate optional scheduled content mediaUrl values before saving
- require HTTP or HTTPS URLs when mediaUrl is provided
- trim valid media URLs before persistence
- add controller coverage for unsafe and valid media URLs

## Why

Scheduled content accepted mediaUrl without type or protocol validation. Rejecting unsafe values keeps invalid media references out of scheduled publishing data.

Fixes #608

## Testing

- npm test -- tests/controllers/scheduleContent.test.js --runInBand --forceExit
- npm run build