### PR TITLE
Feature/issue 637 context menu

### DIFF
--- a/src/components/ContextMenuProvider.jsx
+++ b/src/components/ContextMenuProvider.jsx
@@ -1,0 +1,179 @@
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+
+// Context to allow child components to programmatically close the menu if needed
+const ContextMenuContext = createContext(null);
+export const useContextMenu = () => useContext(ContextMenuContext);
+
+/**
+ * Registry mapping data attributes to specific context menu structures.
+ * In a production app, this could be passed in as a prop or dynamically registered.
+ */
+const MENU_REGISTRY = {
+  'video-item': [
+    { label: 'Play Video', action: 'play', icon: '▶' },
+    { label: 'Edit Metadata', action: 'edit', icon: '✎' },
+    { label: 'Share Link', action: 'share', icon: '🔗' },
+    { type: 'divider' },
+    { label: 'Delete Video', action: 'delete', icon: '🗑', danger: true }
+  ],
+  'file-item': [
+    { label: 'Open File', action: 'open', icon: '📄' },
+    { label: 'Rename', action: 'rename', icon: '✎' },
+    { label: 'Download', action: 'download', icon: '⬇' },
+    { type: 'divider' },
+    { label: 'Move to Trash', action: 'delete', icon: '🗑', danger: true }
+  ]
+};
+
+/**
+ * ContextMenuProvider
+ * Intercepts right-clicks globally, prevents default browser behavior on designated 
+ * elements, and renders a custom UI menu at safely calculated viewport coordinates.
+ */
+export const ContextMenuProvider = ({ children }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [menuItems, setMenuItems] = useState([]);
+  const [contextData, setContextData] = useState(null);
+
+  const hideMenu = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  useEffect(() => {
+    const handleContextMenu = (e) => {
+      // Traverse up the DOM tree to see if the clicked target (or its parents) 
+      // has the designated data attribute.
+      const target = e.target.closest('[data-context-menu]');
+      
+      if (!target) {
+        // Not a designated element; hide our custom menu and let the browser's default menu show.
+        hideMenu();
+        return;
+      }
+
+      // Prevent the default browser context menu from appearing
+      e.preventDefault(); 
+
+      const contextType = target.getAttribute('data-context-menu');
+      const payloadId = target.getAttribute('data-context-id');
+
+      const items = MENU_REGISTRY[contextType];
+
+      if (items && items.length > 0) {
+        setMenuItems(items);
+        setContextData({ type: contextType, id: payloadId });
+        
+        // Anti-clipping Math: Calculate safe X/Y coordinates
+        const MENU_WIDTH = 220; 
+        const ITEM_HEIGHT = 36;
+        const DIVIDER_HEIGHT = 9;
+        
+        // Estimate height based on items and dividers
+        const MENU_HEIGHT = items.reduce((acc, curr) => 
+          acc + (curr.type === 'divider' ? DIVIDER_HEIGHT : ITEM_HEIGHT)
+        , 0) + 16; // 16px for padding top/bottom
+
+        let x = e.clientX;
+        let y = e.clientY;
+
+        // If the menu extends past the right edge, flip it to the left
+        if (x + MENU_WIDTH > window.innerWidth) {
+          x = window.innerWidth - MENU_WIDTH - 8;
+        }
+        
+        // If the menu extends past the bottom edge, flip it upwards
+        if (y + MENU_HEIGHT > window.innerHeight) {
+          y = window.innerHeight - MENU_HEIGHT - 8;
+        }
+
+        setPosition({ x, y });
+        setIsVisible(true);
+      }
+    };
+
+    const handleClickOutside = () => {
+      if (isVisible) hideMenu();
+    };
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && isVisible) hideMenu();
+    };
+
+    window.addEventListener('contextmenu', handleContextMenu);
+    window.addEventListener('click', handleClickOutside);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('contextmenu', handleContextMenu);
+      window.removeEventListener('click', handleClickOutside);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isVisible, hideMenu]);
+
+  // Handle clicking a menu item
+  const handleAction = (item) => {
+    console.log(`Context Action Dispatched: [${item.action}] for Entity ID: ${contextData?.id}`);
+    
+    // TODO: In a full app, dispatch to a global event bus or use a specialized context here
+    // eventBus.emit(item.action, contextData);
+    
+    hideMenu();
+  };
+
+  return (
+    <ContextMenuContext.Provider value={{ hideMenu }}>
+      {children}
+      
+      {/* The floating Custom Menu */}
+      {isVisible && (
+        <div 
+          style={{
+            position: 'fixed',
+            top: position.y,
+            left: position.x,
+            width: '220px',
+            backgroundColor: '#ffffff',
+            borderRadius: '8px',
+            boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.15), 0 8px 10px -6px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0,0,0,0.05)',
+            padding: '8px 0',
+            zIndex: 999999, // Ensure it's above absolute everything (modals, toasts, etc)
+            fontFamily: 'system-ui, sans-serif'
+          }}
+          // Stop clicks inside the menu from immediately triggering the window 'click' listener that hides the menu
+          onClick={(e) => e.stopPropagation()}
+          onContextMenu={(e) => e.preventDefault()}
+        >
+          {menuItems.map((item, idx) => {
+            if (item.type === 'divider') {
+              return <div key={`div-${idx}`} style={{ height: '1px', backgroundColor: '#e2e8f0', margin: '4px 0' }}></div>;
+            }
+
+            return (
+              <div 
+                key={idx}
+                onClick={() => handleAction(item)}
+                style={{
+                  padding: '8px 16px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  fontWeight: '500',
+                  color: item.danger ? '#ef4444' : '#334155',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '12px',
+                  transition: 'background-color 0.1s'
+                }}
+                onMouseOver={(e) => e.currentTarget.style.backgroundColor = item.danger ? '#fef2f2' : '#f1f5f9'}
+                onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+              >
+                {item.icon && <span style={{ fontSize: '16px', width: '20px', textAlign: 'center', opacity: item.danger ? 1 : 0.6 }}>{item.icon}</span>}
+                {item.label}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </ContextMenuContext.Provider>
+  );
+};

--- a/src/components/InfiniteScrollWrapper.jsx
+++ b/src/components/InfiniteScrollWrapper.jsx
@@ -1,0 +1,90 @@
+import React, { useRef, useEffect } from 'react';
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+
+/**
+ * A wrapper component that implements infinite scrolling for a list of children.
+ * 
+ * @param {React.ReactNode} children - The list items to render above the scroll sentinel
+ * @param {Function} fetchNextPage - Callback to execute when the bottom of the list is reached
+ * @param {boolean} hasNextPage - Determines if the observer should continue watching
+ * @param {boolean} isFetchingNextPage - Prevents duplicate fetch calls while a request is pending
+ */
+const InfiniteScrollWrapper = ({ 
+  children, 
+  fetchNextPage, 
+  hasNextPage, 
+  isFetchingNextPage 
+}) => {
+  // Create a ref for the "Sentinel" DOM node placed at the bottom of the list
+  const loadMoreRef = useRef(null);
+  
+  // Use the custom hook to monitor the sentinel's visibility
+  const isVisible = useIntersectionObserver(loadMoreRef, {
+    // rootMargin '100px' triggers the intersection slightly before the user 
+    // actually hits the bottom, providing a seamless scrolling experience.
+    rootMargin: '100px', 
+    threshold: 0
+  });
+
+  // Effect to trigger the fetch callback when the sentinel becomes visible
+  useEffect(() => {
+    if (isVisible && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [isVisible, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <>
+      {/* Render the main content (the long list) */}
+      {children}
+      
+      {/* 
+        The Sentinel Element:
+        This sits at the bottom of the list. When it scrolls into view, 
+        the Intersection Observer fires.
+      */}
+      <div 
+        ref={loadMoreRef} 
+        style={{ 
+          height: '60px', 
+          display: 'flex', 
+          justifyContent: 'center', 
+          alignItems: 'center',
+          marginTop: '16px',
+          fontFamily: 'system-ui, sans-serif'
+        }}
+      >
+        {isFetchingNextPage && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {/* Simple CSS Spinner */}
+            <span style={{
+              display: 'inline-block',
+              width: '16px',
+              height: '16px',
+              border: '2px solid #cbd5e1',
+              borderTopColor: '#3b82f6',
+              borderRadius: '50%',
+              animation: 'spin 1s linear infinite'
+            }}>
+              <style>
+                {`@keyframes spin { to { transform: rotate(360deg); } }`}
+              </style>
+            </span>
+            <span style={{ color: '#64748b', fontSize: '14px', fontWeight: '500' }}>
+              Loading more content...
+            </span>
+          </div>
+        )}
+        
+        {/* Render a friendly message when we hit the absolute end of the database */}
+        {!hasNextPage && (
+          <span style={{ color: '#94a3b8', fontSize: '14px', fontWeight: '500' }}>
+            You've reached the end! 🎉
+          </span>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default InfiniteScrollWrapper;

--- a/src/components/KanbanBoard/Board.jsx
+++ b/src/components/KanbanBoard/Board.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import {
+  DndContext,
+  closestCorners,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import Column from './Column';
+
+const initialData = {
+  columns: {
+    'col-1': { id: 'col-1', title: 'Idea', cardIds: ['card-1', 'card-2'] },
+    'col-2': { id: 'col-2', title: 'Scripting', cardIds: ['card-3', 'card-4'] },
+    'col-3': { id: 'col-3', title: 'Recording', cardIds: [] },
+    'col-4': { id: 'col-4', title: 'Editing', cardIds: ['card-5'] },
+    'col-5': { id: 'col-5', title: 'Published', cardIds: [] },
+  },
+  cards: {
+    'card-1': { id: 'card-1', title: 'Vlog: Day in the Life' },
+    'card-2': { id: 'card-2', title: 'Review: New Camera Gear' },
+    'card-3': { id: 'card-3', title: 'Tutorial: Editing tips' },
+    'card-4': { id: 'card-4', title: 'Podcast Ep 12 Outline' },
+    'card-5': { id: 'card-5', title: 'Shorts Compilation' },
+  },
+  columnOrder: ['col-1', 'col-2', 'col-3', 'col-4', 'col-5'],
+};
+
+// Mock API call for background optimistic updates
+const mockApiUpdate = async (cardId, destinationCol) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      console.log(`[API Mock] Successfully updated ${cardId} to column: ${destinationCol}`);
+      resolve();
+    }, 500);
+  });
+};
+
+const Board = () => {
+  const [data, setData] = useState(initialData);
+
+  // Setup sensors, including keyboard for accessibility
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+
+    if (!over) return;
+
+    const activeId = active.id;
+    const overId = over.id;
+
+    // Find the starting column
+    const startColumn = Object.values(data.columns).find(col =>
+      col.cardIds.includes(activeId)
+    );
+    
+    // Determine the finishing column
+    let finishColumnId = overId;
+    if (data.cards[overId]) {
+      // if dropped over a card, find the column that card belongs to
+      finishColumnId = Object.values(data.columns).find(col =>
+        col.cardIds.includes(overId)
+      ).id;
+    }
+    const finishColumn = data.columns[finishColumnId];
+
+    if (!startColumn || !finishColumn) return;
+
+    // Moving within the same column
+    if (startColumn === finishColumn) {
+      const newCardIds = Array.from(startColumn.cardIds);
+      const oldIndex = newCardIds.indexOf(activeId);
+      const newIndex = newCardIds.indexOf(overId);
+      
+      if (oldIndex !== newIndex) {
+        newCardIds.splice(oldIndex, 1);
+        if (newIndex === -1) {
+          newCardIds.push(activeId);
+        } else {
+          newCardIds.splice(newIndex, 0, activeId);
+        }
+        
+        setData(prev => ({
+          ...prev,
+          columns: {
+            ...prev.columns,
+            [startColumn.id]: {
+              ...startColumn,
+              cardIds: newCardIds
+            }
+          }
+        }));
+      }
+      return;
+    }
+
+    // Moving between different columns
+    const startCardIds = Array.from(startColumn.cardIds);
+    startCardIds.splice(startCardIds.indexOf(activeId), 1);
+
+    const finishCardIds = Array.from(finishColumn.cardIds);
+    const newIndex = finishCardIds.indexOf(overId);
+    
+    if (newIndex === -1) {
+       finishCardIds.push(activeId);
+    } else {
+       finishCardIds.splice(newIndex, 0, activeId);
+    }
+
+    // Optimistic UI update
+    setData(prev => ({
+      ...prev,
+      columns: {
+        ...prev.columns,
+        [startColumn.id]: {
+          ...startColumn,
+          cardIds: startCardIds
+        },
+        [finishColumn.id]: {
+          ...finishColumn,
+          cardIds: finishCardIds
+        }
+      }
+    }));
+
+    // Trigger mock API update in the background
+    mockApiUpdate(activeId, finishColumn.id).catch(console.error);
+  };
+
+  return (
+    <div style={{ padding: '24px', backgroundColor: '#f1f5f9', minHeight: '100vh', fontFamily: 'sans-serif' }}>
+      <h2 style={{ margin: '0 0 24px 0', color: '#1e293b' }}>Content Pipeline</h2>
+      <div style={{ display: 'flex', overflowX: 'auto', paddingBottom: '16px' }}>
+        <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+          {data.columnOrder.map(columnId => {
+            const column = data.columns[columnId];
+            const cards = column.cardIds.map(cardId => data.cards[cardId]);
+            return <Column key={column.id} id={column.id} title={column.title} cards={cards} />;
+          })}
+        </DndContext>
+      </div>
+    </div>
+  );
+};
+
+export default Board;

--- a/src/components/KanbanBoard/Card.jsx
+++ b/src/components/KanbanBoard/Card.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+const Card = ({ id, title }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+    padding: '16px',
+    margin: '0 0 12px 0',
+    backgroundColor: '#ffffff',
+    borderRadius: '8px',
+    boxShadow: isDragging 
+      ? '0 8px 16px rgba(0,0,0,0.1)' 
+      : '0 2px 4px rgba(0,0,0,0.05)',
+    cursor: 'grab',
+    border: '1px solid #e2e8f0',
+    fontWeight: '500',
+    color: '#334155'
+  };
+
+  return (
+    <div 
+      ref={setNodeRef} 
+      style={style} 
+      {...attributes} 
+      {...listeners}
+      aria-label={`Draggable card: ${title}`}
+    >
+      {title}
+    </div>
+  );
+};
+
+export default Card;

--- a/src/components/KanbanBoard/Column.jsx
+++ b/src/components/KanbanBoard/Column.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import Card from './Card';
+
+const Column = ({ id, title, cards }) => {
+  const { setNodeRef } = useDroppable({
+    id: id,
+  });
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#f8fafc',
+        borderRadius: '12px',
+        width: '320px',
+        padding: '16px',
+        margin: '0 16px 0 0',
+        flexShrink: 0,
+        boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+        <h3 style={{ margin: 0, fontSize: '15px', fontWeight: '600', color: '#475569' }}>
+          {title}
+        </h3>
+        <span style={{ background: '#e2e8f0', color: '#64748b', fontSize: '12px', padding: '2px 8px', borderRadius: '12px', fontWeight: 'bold' }}>
+          {cards.length}
+        </span>
+      </div>
+
+      <div ref={setNodeRef} style={{ flexGrow: 1, minHeight: '150px' }}>
+        <SortableContext items={cards.map(c => c.id)} strategy={verticalListSortingStrategy}>
+          {cards.map(card => (
+            <Card key={card.id} id={card.id} title={card.title} />
+          ))}
+        </SortableContext>
+      </div>
+    </div>
+  );
+};
+
+export default Column;

--- a/src/components/ToastContainer.jsx
+++ b/src/components/ToastContainer.jsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import { useToast } from '../contexts/ToastContext';
+
+// Internal component to handle the lifecycle and animation of a single toast
+const ToastItem = ({ toast, removeToast }) => {
+  const [isClosing, setIsClosing] = useState(false);
+
+  // Handle the automatic exit animation based on the duration
+  useEffect(() => {
+    if (toast.duration > 0) {
+      // Trigger the slide-out animation 300ms before the actual unmount
+      const animationTimer = setTimeout(() => {
+        setIsClosing(true);
+      }, toast.duration - 300);
+
+      // Actually remove from DOM after the animation completes
+      const removeTimer = setTimeout(() => {
+        removeToast(toast.id);
+      }, toast.duration);
+
+      return () => {
+        clearTimeout(animationTimer);
+        clearTimeout(removeTimer);
+      };
+    }
+  }, [toast.duration, toast.id, removeToast]);
+
+  const handleManualClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      removeToast(toast.id);
+    }, 300); // Wait for the slide-out animation to finish
+  };
+
+  const getTheme = () => {
+    switch (toast.type) {
+      case 'success': return { bg: '#10b981', icon: '✓' };
+      case 'error': return { bg: '#ef4444', icon: '✕' };
+      case 'warning': return { bg: '#f59e0b', icon: '⚠️' };
+      case 'info':
+      default: return { bg: '#3b82f6', icon: 'ℹ' };
+    }
+  };
+
+  const theme = getTheme();
+
+  return (
+    <div
+      style={{
+        backgroundColor: theme.bg,
+        color: '#ffffff',
+        padding: '12px 16px',
+        borderRadius: '8px',
+        marginBottom: '12px',
+        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        minWidth: '280px',
+        maxWidth: '380px',
+        pointerEvents: 'auto',
+        // Toggle the animation based on state
+        animation: isClosing ? 'toast-slide-out 0.3s ease forwards' : 'toast-slide-in 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+        transformOrigin: 'top right'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <span style={{ fontWeight: 'bold', fontSize: '18px' }}>{theme.icon}</span>
+        <span style={{ fontSize: '14px', lineHeight: '1.4', fontWeight: '500' }}>{toast.message}</span>
+      </div>
+      <button 
+        onClick={handleManualClose}
+        aria-label="Close notification"
+        style={{
+          background: 'none',
+          border: 'none',
+          color: 'rgba(255,255,255,0.8)',
+          cursor: 'pointer',
+          padding: '4px',
+          marginLeft: '12px',
+          fontSize: '20px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          outline: 'none',
+          transition: 'color 0.2s'
+        }}
+        onMouseOver={(e) => e.currentTarget.style.color = '#fff'}
+        onMouseOut={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.8)'}
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export const ToastContainer = () => {
+  const { toasts, removeToast } = useToast();
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '24px',
+        right: '24px',
+        zIndex: 9999, // Ensure it always sits on top of modals/overlays
+        pointerEvents: 'none', // Let clicks pass through the invisible container
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-end',
+      }}
+    >
+      {/* Inject Keyframe animations for the toasts */}
+      <style>
+        {`
+          @keyframes toast-slide-in {
+            from {
+              transform: translateX(120%);
+              opacity: 0;
+            }
+            to {
+              transform: translateX(0);
+              opacity: 1;
+            }
+          }
+          @keyframes toast-slide-out {
+            from {
+              transform: translateX(0);
+              opacity: 1;
+            }
+            to {
+              transform: translateX(120%);
+              opacity: 0;
+            }
+          }
+        `}
+      </style>
+      
+      {/* Map over the active toasts in state */}
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} removeToast={removeToast} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/advanced/VirtualizedList.jsx
+++ b/src/components/advanced/VirtualizedList.jsx
@@ -1,0 +1,82 @@
+import React, { useState, useRef, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * A highly optimized custom Virtualized List (Windowing) component 
+ * that only renders the items currently visible in the viewport.
+ */
+const VirtualizedList = ({ 
+  data, 
+  itemHeight, 
+  containerHeight, 
+  renderRow, 
+  overscan = 5 
+}) => {
+  const [scrollTop, setScrollTop] = useState(0);
+  const containerRef = useRef(null);
+
+  // Calculate the total height of the scroll container dynamically
+  const totalHeight = useMemo(() => data.length * itemHeight, [data.length, itemHeight]);
+
+  // Determine the start and end indices of the items to render, including the overscan buffer
+  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
+  const endIndex = Math.min(
+    data.length - 1, 
+    Math.floor((scrollTop + containerHeight) / itemHeight) + overscan
+  );
+
+  // Update the rendered slice of items strictly based on the scroll position
+  const visibleItems = useMemo(() => {
+    const items = [];
+    for (let i = startIndex; i <= endIndex; i++) {
+      // Ensure we have data at this index before rendering
+      if (data[i] !== undefined) {
+        items.push(
+          <div
+            key={i}
+            style={{
+              position: 'absolute',
+              top: i * itemHeight,
+              height: itemHeight,
+              width: '100%',
+            }}
+          >
+            {renderRow(data[i], i)}
+          </div>
+        );
+      }
+    }
+    return items;
+  }, [startIndex, endIndex, data, itemHeight, renderRow]);
+
+  const handleScroll = (e) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      style={{
+        height: containerHeight,
+        overflowY: 'auto',
+        position: 'relative',
+        willChange: 'transform' // Hardware acceleration hint for smoother scrolling
+      }}
+    >
+      <div style={{ height: totalHeight, position: 'relative' }}>
+        {visibleItems}
+      </div>
+    </div>
+  );
+};
+
+VirtualizedList.propTypes = {
+  data: PropTypes.array.isRequired,
+  itemHeight: PropTypes.number.isRequired,
+  containerHeight: PropTypes.number.isRequired,
+  renderRow: PropTypes.func.isRequired,
+  overscan: PropTypes.number,
+};
+
+export default VirtualizedList;

--- a/src/components/analytics/AdvancedDateRangePicker.jsx
+++ b/src/components/analytics/AdvancedDateRangePicker.jsx
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import { 
+  format, 
+  addMonths, 
+  subMonths, 
+  startOfMonth, 
+  endOfMonth, 
+  startOfWeek, 
+  endOfWeek, 
+  isSameMonth, 
+  isSameDay, 
+  addDays, 
+  subDays,
+  startOfYear,
+  isBefore,
+  isAfter
+} from 'date-fns';
+// Note: In production, ensure `date-fns-tz` is installed to handle advanced timezone math
+// import { formatInTimeZone, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
+
+const TIMEZONES = [
+  'UTC', 
+  'America/New_York', 
+  'America/Los_Angeles', 
+  'Europe/London', 
+  'Asia/Tokyo', 
+  'Australia/Sydney'
+];
+
+const PRESETS = [
+  { label: 'Today', getValue: () => [new Date(), new Date()] },
+  { label: 'Yesterday', getValue: () => [subDays(new Date(), 1), subDays(new Date(), 1)] },
+  { label: 'Last 7 Days', getValue: () => [subDays(new Date(), 6), new Date()] },
+  { label: 'Last 30 Days', getValue: () => [subDays(new Date(), 29), new Date()] },
+  { label: 'This Year', getValue: () => [startOfYear(new Date()), new Date()] },
+];
+
+/**
+ * Internal single-month Calendar component.
+ */
+const Calendar = ({ currentMonth, startDate, endDate, onDateClick }) => {
+  const monthStart = startOfMonth(currentMonth);
+  const monthEnd = endOfMonth(monthStart);
+  const startDateOfWeek = startOfWeek(monthStart);
+  const endDateOfWeek = endOfWeek(monthEnd);
+
+  const rows = [];
+  let days = [];
+  let day = startDateOfWeek;
+
+  while (day <= endDateOfWeek) {
+    for (let i = 0; i < 7; i++) {
+      const formattedDate = format(day, "d");
+      const cloneDay = day;
+      
+      let isSelected = false;
+      let isInRange = false;
+      
+      if (startDate && isSameDay(day, startDate)) isSelected = true;
+      if (endDate && isSameDay(day, endDate)) isSelected = true;
+      if (startDate && endDate && isAfter(day, startDate) && isBefore(day, endDate)) isInRange = true;
+
+      const isCurrentMonth = isSameMonth(day, monthStart);
+
+      days.push(
+        <div 
+          key={day.toISOString()} 
+          onClick={() => onDateClick(cloneDay)}
+          style={{ 
+            padding: '8px', 
+            margin: '2px',
+            textAlign: 'center',
+            cursor: 'pointer',
+            backgroundColor: isSelected ? '#3b82f6' : isInRange ? '#dbeafe' : 'transparent',
+            color: isSelected ? '#ffffff' : !isCurrentMonth ? '#cbd5e1' : '#334155',
+            borderRadius: isSelected ? '6px' : '0',
+            fontWeight: isSelected ? 'bold' : 'normal',
+            transition: 'background-color 0.2s'
+          }}
+          onMouseOver={(e) => {
+            if (!isSelected && !isInRange) e.currentTarget.style.backgroundColor = '#f1f5f9';
+          }}
+          onMouseOut={(e) => {
+            if (!isSelected && !isInRange) e.currentTarget.style.backgroundColor = 'transparent';
+          }}
+        >
+          {formattedDate}
+        </div>
+      );
+      day = addDays(day, 1);
+    }
+    rows.push(<div key={day.toISOString()} style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' }}>{days}</div>);
+    days = [];
+  }
+
+  return (
+    <div style={{ width: '260px' }}>
+      <div style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: '16px', color: '#1e293b' }}>
+        {format(currentMonth, "MMMM yyyy")}
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', fontWeight: 'bold', textAlign: 'center', marginBottom: '8px', color: '#64748b', fontSize: '12px' }}>
+        {['Su','Mo','Tu','We','Th','Fr','Sa'].map(d => <div key={d}>{d}</div>)}
+      </div>
+      {rows}
+    </div>
+  );
+};
+
+const AdvancedDateRangePicker = ({ onChange }) => {
+  const [currentMonthLeft, setCurrentMonthLeft] = useState(new Date());
+  const [currentMonthRight, setCurrentMonthRight] = useState(addMonths(new Date(), 1));
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+  const [timezone, setTimezone] = useState('UTC');
+
+  const handleDateClick = (day) => {
+    // If no start date, or both dates exist, start a new selection
+    if (!startDate || (startDate && endDate) || isBefore(day, startDate)) {
+      setStartDate(day);
+      setEndDate(null);
+    } else {
+      // Validate that end date is strictly after or equal to start date
+      setEndDate(day);
+      if (onChange) {
+         onChange({ startDate, endDate: day, timezone });
+      }
+    }
+  };
+
+  const applyPreset = (preset) => {
+    const [start, end] = preset.getValue();
+    setStartDate(start);
+    setEndDate(end);
+    
+    // Shift calendars to view the newly selected start date
+    setCurrentMonthLeft(start);
+    setCurrentMonthRight(addMonths(start, 1));
+    
+    if (onChange) {
+       onChange({ startDate: start, endDate: end, timezone });
+    }
+  };
+
+  const handlePrevMonth = () => {
+    setCurrentMonthLeft(subMonths(currentMonthLeft, 1));
+    setCurrentMonthRight(subMonths(currentMonthRight, 1));
+  };
+
+  const handleNextMonth = () => {
+    setCurrentMonthLeft(addMonths(currentMonthLeft, 1));
+    setCurrentMonthRight(addMonths(currentMonthRight, 1));
+  };
+
+  return (
+    <div style={{ display: 'flex', border: '1px solid #e2e8f0', borderRadius: '12px', overflow: 'hidden', width: 'fit-content', fontFamily: 'sans-serif', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}>
+      
+      {/* Sidebar Presets */}
+      <div style={{ width: '160px', borderRight: '1px solid #e2e8f0', backgroundColor: '#f8fafc', padding: '12px 0' }}>
+        <h4 style={{ margin: '0 0 12px 16px', color: '#64748b', fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Presets</h4>
+        {PRESETS.map((preset, idx) => (
+          <div 
+            key={idx} 
+            onClick={() => applyPreset(preset)}
+            style={{ padding: '12px 16px', cursor: 'pointer', fontSize: '14px', color: '#334155', fontWeight: '500', transition: 'background-color 0.2s' }}
+            onMouseOver={(e) => e.target.style.backgroundColor = '#e2e8f0'}
+            onMouseOut={(e) => e.target.style.backgroundColor = 'transparent'}
+          >
+            {preset.label}
+          </div>
+        ))}
+      </div>
+
+      {/* Main Dual-Calendar Area */}
+      <div style={{ padding: '24px', backgroundColor: '#ffffff' }}>
+        
+        {/* Header / Timezone Select */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+             <span style={{ fontSize: '13px', color: '#64748b', fontWeight: 'bold' }}>Timezone:</span>
+             <select 
+                value={timezone} 
+                onChange={(e) => {
+                  setTimezone(e.target.value);
+                  if (onChange && startDate && endDate) onChange({ startDate, endDate, timezone: e.target.value });
+                }}
+                style={{ padding: '6px 12px', borderRadius: '6px', border: '1px solid #cbd5e1', outline: 'none', cursor: 'pointer', fontSize: '13px', color: '#334155' }}
+             >
+                {TIMEZONES.map(tz => <option key={tz} value={tz}>{tz}</option>)}
+             </select>
+          </div>
+          
+          <div style={{ fontSize: '14px', color: '#334155', fontWeight: '600', backgroundColor: '#f1f5f9', padding: '6px 12px', borderRadius: '6px' }}>
+            {startDate ? format(startDate, 'MMM d, yyyy') : 'Start Date'} 
+            {' — '} 
+            {endDate ? format(endDate, 'MMM d, yyyy') : 'End Date'}
+          </div>
+        </div>
+
+        {/* Calendars */}
+        <div style={{ display: 'flex', gap: '40px' }}>
+          <div style={{ position: 'relative' }}>
+             <button onClick={handlePrevMonth} style={{ position: 'absolute', top: 0, left: 0, background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px', color: '#64748b' }}>&lt;</button>
+             <Calendar currentMonth={currentMonthLeft} startDate={startDate} endDate={endDate} onDateClick={handleDateClick} />
+          </div>
+          <div style={{ position: 'relative' }}>
+             <button onClick={handleNextMonth} style={{ position: 'absolute', top: 0, right: 0, background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px', color: '#64748b' }}>&gt;</button>
+             <Calendar currentMonth={currentMonthRight} startDate={startDate} endDate={endDate} onDateClick={handleDateClick} />
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedDateRangePicker;

--- a/src/components/analytics/ExportAnalyticsButton.jsx
+++ b/src/components/analytics/ExportAnalyticsButton.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useCsvWorker } from '../../hooks/useCsvWorker';
+
+const ExportAnalyticsButton = ({ data, filename }) => {
+  const { exportCsv, isExporting, error } = useCsvWorker();
+
+  const handleExport = () => {
+    exportCsv(data, filename);
+  };
+
+  return (
+    <div style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+      <button 
+        onClick={handleExport} 
+        disabled={isExporting || !data || data.length === 0}
+        style={{
+          padding: '10px 20px',
+          backgroundColor: isExporting ? '#94a3b8' : '#2563eb',
+          color: '#ffffff',
+          border: 'none',
+          borderRadius: '8px',
+          cursor: isExporting || !data || data.length === 0 ? 'not-allowed' : 'pointer',
+          fontWeight: '600',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          transition: 'background-color 0.2s',
+          fontSize: '14px'
+        }}
+      >
+        {isExporting ? (
+          <>
+            <span style={{
+              display: 'inline-block',
+              width: '16px',
+              height: '16px',
+              border: '3px solid rgba(255,255,255,0.3)',
+              borderTopColor: '#ffffff',
+              borderRadius: '50%',
+              animation: 'spin 1s linear infinite'
+            }}>
+              <style>
+                {`@keyframes spin { to { transform: rotate(360deg); } }`}
+              </style>
+            </span>
+            Processing...
+          </>
+        ) : (
+          'Export Analytics (CSV)'
+        )}
+      </button>
+      {error && <div style={{ color: '#ef4444', marginTop: '8px', fontSize: '13px', fontWeight: '500' }}>Error: {error}</div>}
+    </div>
+  );
+};
+
+export default ExportAnalyticsButton;

--- a/src/components/auth/RequirePermission.jsx
+++ b/src/components/auth/RequirePermission.jsx
@@ -1,0 +1,77 @@
+import React, { useMemo } from 'react';
+
+// NOTE: In the real application, import `useAuth` from your actual Authentication Context.
+// import { useAuth } from '../../contexts/AuthContext';
+
+// Mock hook implementation for demonstration purposes so the component functions independently.
+const useAuth = () => {
+  return {
+    user: {
+      role: 'editor', // e.g., 'admin', 'manager', 'editor'
+      permissions: ['create_post', 'edit_post', 'view_analytics'] 
+    }
+  };
+};
+
+/**
+ * RequirePermission
+ * A declarative Role-Based Access Control (RBAC) wrapper component.
+ * 
+ * @param {string|Array<string>} requiredRole - Role(s) required to view the content (e.g., 'admin' or ['admin', 'manager'])
+ * @param {Array<string>} allowedActions - Specific granular permissions required (e.g., ['delete_post', 'publish_post'])
+ * @param {React.ReactNode} fallback - Component to render if access is denied (defaults to null/hidden)
+ * @param {React.ReactNode} children - Content to render if access is granted
+ */
+const RequirePermission = ({ 
+  requiredRole, 
+  allowedActions = [], 
+  fallback = null, 
+  children 
+}) => {
+  const { user } = useAuth();
+
+  // Heavily memoize the permission evaluation to prevent UI stutter during React renders
+  const hasAccess = useMemo(() => {
+    if (!user) return false;
+
+    const userRole = user.role?.toLowerCase();
+
+    // 1. Role-based check
+    if (requiredRole) {
+      const targetRoles = Array.isArray(requiredRole) 
+        ? requiredRole.map(r => r.toLowerCase()) 
+        : [requiredRole.toLowerCase()];
+      
+      if (!targetRoles.includes(userRole)) {
+        // Supreme admin override fallback
+        if (userRole !== 'admin') {
+           return false;
+        }
+      }
+    }
+
+    // 2. Action/Permission-based check
+    if (allowedActions && allowedActions.length > 0) {
+      const userPermissions = user.permissions || [];
+      
+      // Ensure the user has EVERY requested action in their permission array
+      const hasAllActions = allowedActions.every(action => userPermissions.includes(action));
+      
+      if (!hasAllActions && userRole !== 'admin') {
+        return false;
+      }
+    }
+
+    return true;
+  }, [user, requiredRole, allowedActions]);
+
+  // If the user fails the evaluation, render the fallback UI (or nothing)
+  if (!hasAccess) {
+    return fallback ? <>{fallback}</> : null;
+  }
+
+  // Render the protected component
+  return <>{children}</>;
+};
+
+export default RequirePermission;

--- a/src/components/forms/DynamicFormBuilder.jsx
+++ b/src/components/forms/DynamicFormBuilder.jsx
@@ -1,0 +1,245 @@
+import React, { useState } from 'react';
+
+/**
+ * DynamicFormBuilder
+ * Generates a form dynamically based on a provided JSON schema.
+ * 
+ * @param {Array} schema - Array of field definition objects
+ * @param {Function} onSubmit - Callback fired with validated form data
+ */
+const DynamicFormBuilder = ({ schema = [], onSubmit }) => {
+  // 1. Initialize centralized state based on the schema defaults
+  const initialState = schema.reduce((acc, field) => {
+    if (field.type === 'checkbox') {
+      acc[field.name] = field.defaultValue || false;
+    } else {
+      acc[field.name] = field.defaultValue || '';
+    }
+    return acc;
+  }, {});
+
+  const [formData, setFormData] = useState(initialState);
+  const [errors, setErrors] = useState({});
+
+  // 2. Validation Logic
+  const validateField = (name, value, fieldSchema) => {
+    // Required check
+    if (fieldSchema.required) {
+      if (fieldSchema.type === 'checkbox' && value === false) {
+         return `${fieldSchema.label} is required`;
+      }
+      if (value === '' || value === null || value === undefined) {
+        return `${fieldSchema.label} is required`;
+      }
+    }
+    
+    // Regex Pattern check
+    if (fieldSchema.pattern && value) {
+      const regex = new RegExp(fieldSchema.pattern);
+      if (!regex.test(value)) {
+        return fieldSchema.errorMsg || `Invalid format for ${fieldSchema.label}`;
+      }
+    }
+    
+    return null;
+  };
+
+  const handleChange = (e, fieldSchema) => {
+    const { name, value, type, checked } = e.target;
+    
+    // Handle checkbox booleans vs standard text values
+    const val = type === 'checkbox' ? checked : value;
+    
+    setFormData(prev => ({
+      ...prev,
+      [name]: val
+    }));
+    
+    // If the field currently has an error, re-validate on change to clear it instantly
+    if (errors[name]) {
+      setErrors(prev => ({
+        ...prev,
+        [name]: validateField(name, val, fieldSchema)
+      }));
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    
+    let newErrors = {};
+    let isValid = true;
+    
+    // Validate all fields before submitting
+    schema.forEach(field => {
+      const err = validateField(field.name, formData[field.name], field);
+      if (err) {
+        newErrors[field.name] = err;
+        isValid = false;
+      }
+    });
+    
+    if (isValid) {
+      setErrors({}); // clear errors
+      if (onSubmit) onSubmit(formData);
+    } else {
+      setErrors(newErrors); // Display inline errors
+    }
+  };
+
+  // 3. Dynamic Renderer
+  const renderField = (field) => {
+    const { type, name, label, options = [] } = field;
+    const value = formData[name];
+    const error = errors[name];
+
+    const inputStyle = {
+      width: '100%',
+      padding: '10px 14px',
+      border: `1px solid ${error ? '#ef4444' : '#cbd5e1'}`,
+      borderRadius: '6px',
+      marginTop: '6px',
+      outlineColor: error ? '#ef4444' : '#3b82f6',
+      fontSize: '14px',
+      color: '#334155',
+      backgroundColor: '#ffffff'
+    };
+
+    switch (type) {
+      case 'textarea':
+        return (
+          <textarea
+            id={name}
+            name={name}
+            value={value}
+            onChange={(e) => handleChange(e, field)}
+            style={{ ...inputStyle, minHeight: '100px', resize: 'vertical' }}
+            aria-invalid={!!error}
+          />
+        );
+      case 'select':
+        return (
+          <select
+            id={name}
+            name={name}
+            value={value}
+            onChange={(e) => handleChange(e, field)}
+            style={inputStyle}
+            aria-invalid={!!error}
+          >
+            <option value="" disabled>Select {label}</option>
+            {options.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        );
+      case 'radio':
+        return (
+          <div style={{ marginTop: '8px', display: 'flex', gap: '16px' }}>
+            {options.map(opt => (
+              <label key={opt.value} style={{ display: 'flex', alignItems: 'center', fontSize: '14px', color: '#475569', cursor: 'pointer' }}>
+                <input
+                  type="radio"
+                  name={name}
+                  value={opt.value}
+                  checked={value === opt.value}
+                  onChange={(e) => handleChange(e, field)}
+                  style={{ marginRight: '6px', cursor: 'pointer', accentColor: '#3b82f6' }}
+                />
+                {opt.label}
+              </label>
+            ))}
+          </div>
+        );
+      case 'checkbox':
+        return (
+          <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              id={name}
+              name={name}
+              checked={value}
+              onChange={(e) => handleChange(e, field)}
+              style={{ marginRight: '10px', width: '16px', height: '16px', cursor: 'pointer', accentColor: '#3b82f6' }}
+            />
+            <label htmlFor={name} style={{ fontSize: '14px', color: '#334155', cursor: 'pointer' }}>
+              {label} {field.required && <span style={{ color: '#ef4444' }}>*</span>}
+            </label>
+          </div>
+        );
+      case 'text':
+      case 'password':
+      case 'email':
+      default:
+        return (
+          <input
+            type={type}
+            id={name}
+            name={name}
+            value={value}
+            onChange={(e) => handleChange(e, field)}
+            style={inputStyle}
+            aria-invalid={!!error}
+          />
+        );
+    }
+  };
+
+  return (
+    <form 
+      onSubmit={handleSubmit} 
+      style={{ 
+        maxWidth: '550px', 
+        padding: '32px', 
+        background: '#f8fafc', 
+        borderRadius: '12px', 
+        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+        fontFamily: 'system-ui, sans-serif'
+      }}
+    >
+      {schema.map(field => (
+        <div key={field.name} style={{ marginBottom: '20px' }}>
+          
+          {/* Checkboxes render their own labels internally for layout reasons */}
+          {field.type !== 'checkbox' && (
+            <label htmlFor={field.name} style={{ display: 'block', fontWeight: '600', fontSize: '14px', color: '#1e293b' }}>
+              {field.label} {field.required && <span style={{ color: '#ef4444' }}>*</span>}
+            </label>
+          )}
+          
+          {renderField(field)}
+          
+          {/* Inline Error Message */}
+          {errors[field.name] && (
+            <div style={{ color: '#ef4444', fontSize: '13px', marginTop: '6px', fontWeight: '500' }}>
+              {errors[field.name]}
+            </div>
+          )}
+        </div>
+      ))}
+      
+      <button 
+        type="submit"
+        style={{
+          padding: '12px 24px',
+          background: '#3b82f6',
+          color: '#ffffff',
+          border: 'none',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          fontWeight: 'bold',
+          fontSize: '15px',
+          width: '100%',
+          marginTop: '12px',
+          transition: 'background-color 0.2s'
+        }}
+        onMouseOver={(e) => e.target.style.backgroundColor = '#2563eb'}
+        onMouseOut={(e) => e.target.style.backgroundColor = '#3b82f6'}
+      >
+        Submit Configuration
+      </button>
+    </form>
+  );
+};
+
+export default DynamicFormBuilder;

--- a/src/components/uploader/ResumableUploader.jsx
+++ b/src/components/uploader/ResumableUploader.jsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { useChunkedUpload } from '../../hooks/useChunkedUpload';
+
+const ResumableUploader = () => {
+  const [file, setFile] = useState(null);
+  const { progress, status, error, start, pause, resume, cancel } = useChunkedUpload(file);
+
+  const handleFileChange = (e) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setFile(e.target.files[0]);
+      cancel(); // Reset any previous uploads
+    }
+  };
+
+  const formatSize = (bytes) => (bytes / (1024 * 1024)).toFixed(2);
+
+  return (
+    <div style={{ border: '1px solid #e2e8f0', padding: '24px', borderRadius: '12px', maxWidth: '450px', fontFamily: 'sans-serif' }}>
+      <h3 style={{ margin: '0 0 16px 0' }}>Upload High-Res Video</h3>
+      <input 
+        type="file" 
+        onChange={handleFileChange} 
+        disabled={status === 'uploading'} 
+        style={{ marginBottom: '16px' }}
+      />
+      
+      {file && (
+        <div style={{ marginTop: '20px' }}>
+          <div style={{ marginBottom: '12px', fontSize: '14px', color: '#334155' }}>
+            <strong>{file.name}</strong> ({formatSize(file.size)} MB)
+          </div>
+          
+          <div style={{ background: '#f1f5f9', height: '12px', borderRadius: '6px', overflow: 'hidden' }}>
+            <div 
+              style={{ 
+                width: `${progress}%`, 
+                background: status === 'error' ? '#ef4444' : status === 'success' ? '#22c55e' : '#3b82f6', 
+                height: '100%',
+                transition: 'width 0.4s ease, background-color 0.3s ease'
+              }} 
+            />
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px', fontSize: '13px', color: '#64748b', fontWeight: '500' }}>
+            <span>{progress}%</span>
+            <span style={{ textTransform: 'capitalize' }}>{status}</span>
+          </div>
+
+          {error && <div style={{ color: '#ef4444', marginTop: '12px', fontSize: '14px' }}>{error}</div>}
+
+          <div style={{ display: 'flex', gap: '12px', marginTop: '24px' }}>
+            {(status === 'idle' || status === 'error') && (
+              <button 
+                onClick={start}
+                style={{ padding: '8px 16px', background: '#3b82f6', color: '#fff', border: 'none', borderRadius: '6px', cursor: 'pointer', fontWeight: '600' }}
+              >
+                Start Upload
+              </button>
+            )}
+            {status === 'uploading' && (
+              <button 
+                onClick={pause}
+                style={{ padding: '8px 16px', background: '#f59e0b', color: '#fff', border: 'none', borderRadius: '6px', cursor: 'pointer', fontWeight: '600' }}
+              >
+                Pause
+              </button>
+            )}
+            {status === 'paused' && (
+              <button 
+                onClick={resume}
+                style={{ padding: '8px 16px', background: '#10b981', color: '#fff', border: 'none', borderRadius: '6px', cursor: 'pointer', fontWeight: '600' }}
+              >
+                Resume
+              </button>
+            )}
+            {(status === 'uploading' || status === 'paused' || status === 'error') && (
+              <button 
+                onClick={cancel}
+                style={{ padding: '8px 16px', background: '#e2e8f0', color: '#475569', border: 'none', borderRadius: '6px', cursor: 'pointer', fontWeight: '600' }}
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResumableUploader;

--- a/src/components/video/AdvancedVideoPlayer.jsx
+++ b/src/components/video/AdvancedVideoPlayer.jsx
@@ -1,0 +1,244 @@
+import React, { useRef, useState, useEffect } from 'react';
+import Hls from 'hls.js';
+
+const AdvancedVideoPlayer = ({ src, poster }) => {
+  const videoRef = useRef(null);
+  const containerRef = useRef(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [isMuted, setIsMuted] = useState(false);
+  const [showControls, setShowControls] = useState(true);
+  
+  const timeoutRef = useRef(null);
+
+  // Initialize HLS.js for .m3u8 streaming formats
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !src) return;
+
+    let hls;
+    if (Hls.isSupported() && src.endsWith('.m3u8')) {
+      hls = new Hls();
+      hls.loadSource(src);
+      hls.attachMedia(video);
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      // Native HLS support (Safari)
+      video.src = src;
+    } else {
+      // Standard MP4 fallback
+      video.src = src;
+    }
+
+    return () => {
+      if (hls) {
+        hls.destroy();
+      }
+    };
+  }, [src]);
+
+  // Autohide controls after 3 seconds of inactivity
+  const handleMouseMove = () => {
+    setShowControls(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setShowControls(false), 3000);
+  };
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const handleTimeUpdate = () => {
+      setCurrentTime(video.currentTime);
+      setProgress((video.currentTime / video.duration) * 100);
+    };
+
+    const handleLoadedMetadata = () => {
+      setDuration(video.duration);
+    };
+
+    video.addEventListener('timeupdate', handleTimeUpdate);
+    video.addEventListener('loadedmetadata', handleLoadedMetadata);
+    
+    return () => {
+      video.removeEventListener('timeupdate', handleTimeUpdate);
+      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
+    };
+  }, []);
+
+  const togglePlay = () => {
+    if (videoRef.current.paused) {
+      videoRef.current.play();
+      setIsPlaying(true);
+    } else {
+      videoRef.current.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  const handleVolumeChange = (e) => {
+    const newVolume = parseFloat(e.target.value);
+    setVolume(newVolume);
+    videoRef.current.volume = newVolume;
+    setIsMuted(newVolume === 0);
+  };
+
+  const toggleMute = () => {
+    if (isMuted) {
+      videoRef.current.volume = volume || 1;
+      setIsMuted(false);
+      if (volume === 0) setVolume(1);
+    } else {
+      videoRef.current.volume = 0;
+      setIsMuted(true);
+    }
+  };
+
+  const handleSeek = (e) => {
+    const seekTime = (parseFloat(e.target.value) / 100) * duration;
+    videoRef.current.currentTime = seekTime;
+    setProgress(e.target.value);
+  };
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      containerRef.current.requestFullscreen().catch(err => {
+        console.error(`Error attempting to enable full-screen mode: ${err.message}`);
+      });
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  const formatTime = (time) => {
+    if (isNaN(time)) return "00:00";
+    const minutes = Math.floor(time / 60);
+    const seconds = Math.floor(time % 60);
+    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+  };
+
+  // Keyboard accessibility
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      // Don't trigger if user is typing in an input
+      if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
+
+      switch(e.key.toLowerCase()) {
+        case ' ':
+          e.preventDefault(); // Prevent scrolling down
+          togglePlay();
+          break;
+        case 'arrowright':
+          videoRef.current.currentTime = Math.min(videoRef.current.currentTime + 5, duration);
+          break;
+        case 'arrowleft':
+          videoRef.current.currentTime = Math.max(videoRef.current.currentTime - 5, 0);
+          break;
+        case 'f':
+          toggleFullscreen();
+          break;
+        default:
+          break;
+      }
+    };
+    
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [duration]);
+
+  return (
+    <div 
+      ref={containerRef} 
+      style={{ position: 'relative', width: '100%', maxWidth: '800px', backgroundColor: '#000', overflow: 'hidden', borderRadius: document.fullscreenElement ? '0' : '12px' }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={() => setShowControls(false)}
+    >
+      <video 
+        ref={videoRef} 
+        poster={poster}
+        onClick={togglePlay}
+        style={{ width: '100%', display: 'block', cursor: 'pointer' }}
+      />
+      
+      {/* Controls Overlay */}
+      <div style={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        padding: '20px 20px 15px 20px',
+        background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)',
+        opacity: showControls ? 1 : 0,
+        transition: 'opacity 0.3s ease',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px'
+      }}>
+        
+        {/* Progress Scrubbing Bar */}
+        <input 
+          type="range" 
+          min="0" 
+          max="100" 
+          value={progress || 0} 
+          onChange={handleSeek}
+          style={{ width: '100%', cursor: 'pointer', accentColor: '#3b82f6', height: '4px' }}
+          aria-label="Video Progress"
+        />
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '20px' }}>
+            <button onClick={togglePlay} style={btnStyle} aria-label="Play/Pause">
+              {isPlaying ? '⏸' : '▶'}
+            </button>
+
+            {/* Volume Control */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <button onClick={toggleMute} style={btnStyle} aria-label="Mute/Unmute">
+                {isMuted || volume === 0 ? '🔇' : '🔊'}
+              </button>
+              <input 
+                type="range" 
+                min="0" 
+                max="1" 
+                step="0.05"
+                value={isMuted ? 0 : volume} 
+                onChange={handleVolumeChange}
+                style={{ width: '80px', cursor: 'pointer', accentColor: '#3b82f6', height: '4px' }}
+                aria-label="Volume"
+              />
+            </div>
+            
+            {/* Timestamp */}
+            <span style={{ color: '#e2e8f0', fontSize: '13px', fontWeight: '500', fontFamily: 'system-ui, sans-serif' }}>
+              {formatTime(currentTime)} / {formatTime(duration)}
+            </span>
+          </div>
+
+          <div>
+            <button onClick={toggleFullscreen} style={btnStyle} aria-label="Fullscreen">
+              ⛶
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const btnStyle = {
+  background: 'none',
+  border: 'none',
+  color: 'white',
+  cursor: 'pointer',
+  fontSize: '20px',
+  padding: '0',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  outline: 'none'
+};
+
+export default AdvancedVideoPlayer;

--- a/src/components/webrtc/AudioStreamer.jsx
+++ b/src/components/webrtc/AudioStreamer.jsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+/**
+ * AudioStreamer
+ * A foundational WebRTC component that accesses the local microphone, 
+ * prepares a Peer-to-Peer connection, and visualizes the audio frequencies.
+ */
+const AudioStreamer = () => {
+  const canvasRef = useRef(null);
+  
+  // Keep track of active media streams and connections to prevent memory leaks
+  const streamRef = useRef(null);
+  const peerConnectionRef = useRef(null);
+  const animationFrameRef = useRef(null);
+  const audioContextRef = useRef(null);
+  
+  const [error, setError] = useState(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  const startStream = async () => {
+    try {
+      // 1. Request Microphone Access
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      streamRef.current = stream;
+      setIsStreaming(true);
+      setError(null);
+
+      // 2. Setup WebRTC Peer Connection Placeholder
+      // Using Google's public STUN server to resolve the local public IP
+      const pc = new RTCPeerConnection({
+        iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+      });
+      peerConnectionRef.current = pc;
+
+      // Add the local audio tracks to the RTC connection
+      stream.getTracks().forEach(track => {
+        pc.addTrack(track, stream);
+      });
+
+      // Generate an SDP Offer (Session Description Protocol)
+      // Since we don't have a signaling server (e.g., Socket.io) yet, we simply log it.
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      console.log('--- WebRTC SDP Offer Created ---');
+      console.log(offer.sdp);
+      console.log('--------------------------------');
+
+      // 3. Setup Web Audio API for the visualizer
+      const AudioContext = window.AudioContext || window.webkitAudioContext;
+      const audioCtx = new AudioContext();
+      audioContextRef.current = audioCtx;
+
+      const source = audioCtx.createMediaStreamSource(stream);
+      const analyzer = audioCtx.createAnalyser();
+      analyzer.fftSize = 256;
+      source.connect(analyzer);
+
+      const bufferLength = analyzer.frequencyBinCount;
+      const dataArray = new Uint8Array(bufferLength);
+      
+      const canvas = canvasRef.current;
+      const canvasCtx = canvas.getContext('2d');
+
+      // Visualizer render loop
+      const draw = () => {
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+
+        // Schedule the next frame
+        animationFrameRef.current = requestAnimationFrame(draw);
+
+        // Populate the data array with current frequency data
+        analyzer.getByteFrequencyData(dataArray);
+
+        // Paint background
+        canvasCtx.fillStyle = '#0f172a'; // Slate-900
+        canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
+
+        const barWidth = (WIDTH / bufferLength) * 2.5;
+        let x = 0;
+
+        for (let i = 0; i < bufferLength; i++) {
+          const barHeight = dataArray[i];
+
+          // Dynamic gradient based on frequency intensity
+          canvasCtx.fillStyle = `rgb(${barHeight + 100}, 99, 235)`; // Blue-ish tone
+          canvasCtx.fillRect(x, HEIGHT - (barHeight / 2), barWidth, barHeight / 2);
+
+          x += barWidth + 1; // Add 1px gap between bars
+        }
+      };
+
+      // Start the loop
+      draw();
+
+    } catch (err) {
+      console.error('Error accessing microphone:', err);
+      setError('Could not access microphone. Please ensure browser permissions are granted.');
+    }
+  };
+
+  const stopStream = () => {
+    // Stop Animation Loop
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+    
+    // Close Audio Context
+    if (audioContextRef.current && audioContextRef.current.state !== 'closed') {
+      audioContextRef.current.close();
+    }
+
+    // EXPLICITLY Stop Media Tracks so the browser recording light turns off
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => {
+        track.stop();
+      });
+      streamRef.current = null;
+    }
+
+    // Close Peer Connection
+    if (peerConnectionRef.current) {
+      peerConnectionRef.current.close();
+      peerConnectionRef.current = null;
+    }
+
+    setIsStreaming(false);
+
+    // Clear Canvas visualizer
+    if (canvasRef.current) {
+      const canvasCtx = canvasRef.current.getContext('2d');
+      canvasCtx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+    }
+  };
+
+  // Ensure absolutely everything cleans up if the component unmounts mid-stream
+  useEffect(() => {
+    return () => {
+      stopStream();
+    };
+  }, []);
+
+  return (
+    <div style={{ maxWidth: '500px', margin: '0 auto', padding: '32px', backgroundColor: '#ffffff', borderRadius: '16px', boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)', fontFamily: 'system-ui, sans-serif' }}>
+      <div style={{ textAlign: 'center', marginBottom: '24px' }}>
+        <h3 style={{ margin: '0 0 8px 0', color: '#1e293b', fontSize: '20px' }}>1-on-1 Audio Room</h3>
+        <p style={{ margin: 0, color: '#64748b', fontSize: '14px' }}>Testing Local WebRTC Connection</p>
+      </div>
+      
+      {error && (
+        <div style={{ padding: '12px', backgroundColor: '#fef2f2', color: '#ef4444', borderRadius: '8px', marginBottom: '20px', border: '1px solid #fecaca', fontSize: '14px' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Visualizer Canvas Container */}
+      <div style={{ backgroundColor: '#0f172a', borderRadius: '12px', overflow: 'hidden', height: '160px', marginBottom: '24px', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.5)' }}>
+        <canvas 
+          ref={canvasRef} 
+          width="500" 
+          height="160" 
+          style={{ width: '100%', height: '100%', display: isStreaming ? 'block' : 'none' }} 
+        />
+        {!isStreaming && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px' }}>
+            <span style={{ fontSize: '32px' }}>🎙️</span>
+            <span style={{ color: '#475569', fontSize: '14px', fontWeight: '500' }}>Microphone Inactive</span>
+          </div>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        {!isStreaming ? (
+          <button 
+            onClick={startStream}
+            style={{ padding: '12px 32px', backgroundColor: '#3b82f6', color: 'white', border: 'none', borderRadius: '8px', fontWeight: 'bold', fontSize: '15px', cursor: 'pointer', transition: 'background-color 0.2s', width: '100%' }}
+            onMouseOver={(e) => e.target.style.backgroundColor = '#2563eb'}
+            onMouseOut={(e) => e.target.style.backgroundColor = '#3b82f6'}
+          >
+            Connect Audio
+          </button>
+        ) : (
+          <button 
+            onClick={stopStream}
+            style={{ padding: '12px 32px', backgroundColor: '#ef4444', color: 'white', border: 'none', borderRadius: '8px', fontWeight: 'bold', fontSize: '15px', cursor: 'pointer', transition: 'background-color 0.2s', width: '100%' }}
+            onMouseOver={(e) => e.target.style.backgroundColor = '#dc2626'}
+            onMouseOut={(e) => e.target.style.backgroundColor = '#ef4444'}
+          >
+            End Connection
+          </button>
+        )}
+      </div>
+      
+      {isStreaming && (
+        <p style={{ textAlign: 'center', marginTop: '20px', fontSize: '13px', color: '#94a3b8' }}>
+          Check your browser developer console to view the raw <strong>WebRTC SDP Offer</strong>.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default AudioStreamer;

--- a/src/components/wizard/Wizard.jsx
+++ b/src/components/wizard/Wizard.jsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { useWizard } from '../../contexts/WizardContext';
+
+/**
+ * Wizard UI Wrapper
+ * 
+ * Consumes the WizardContext to render the visual stepper, the current active 
+ * step component, and the Next/Back navigation controls.
+ * 
+ * @param {Function} onComplete - Callback fired when the final step is submitted. Receives full formData.
+ */
+export const Wizard = ({ onComplete }) => {
+  const { 
+    currentStep, 
+    steps, 
+    nextStep, 
+    prevStep, 
+    isFirstStep, 
+    isLastStep,
+    formData,
+    updateFormData,
+    isNavigating,
+    clearWizard
+  } = useWizard();
+
+  // Safely extract the component designated for the current step
+  const StepComponent = steps[currentStep]?.component;
+
+  if (!StepComponent) {
+    return (
+      <div style={{ padding: '20px', color: '#ef4444', border: '1px solid #ef4444', borderRadius: '8px', background: '#fef2f2' }}>
+        <strong>Configuration Error:</strong> Invalid Wizard Step at index {currentStep}.
+      </div>
+    );
+  }
+
+  const handleFinalSubmit = async () => {
+    // We still validate the final step before triggering onComplete
+    const isValid = await nextStep(); 
+    if (isValid && typeof onComplete === 'function') {
+      onComplete(formData, clearWizard);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '700px', margin: '0 auto', padding: '32px', fontFamily: 'system-ui, sans-serif', background: '#ffffff', borderRadius: '12px', boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)' }}>
+      
+      {/* 1. Progress Bar / Stepper Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '32px', position: 'relative' }}>
+        
+        {/* Background track line */}
+        <div style={{ position: 'absolute', top: '50%', left: '0', right: '0', height: '3px', background: '#e2e8f0', zIndex: 1, transform: 'translateY(-50%)' }}></div>
+        
+        {/* Progress track line */}
+        <div style={{ position: 'absolute', top: '50%', left: '0', width: `${(currentStep / (steps.length - 1)) * 100}%`, height: '3px', background: '#3b82f6', zIndex: 2, transform: 'translateY(-50%)', transition: 'width 0.3s ease' }}></div>
+
+        {steps.map((step, index) => {
+          const isCompleted = index < currentStep;
+          const isActive = index === currentStep;
+          
+          return (
+            <div key={index} style={{ position: 'relative', zIndex: 3, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <div style={{ 
+                width: '32px', 
+                height: '32px', 
+                borderRadius: '50%', 
+                display: 'flex', 
+                alignItems: 'center', 
+                justifyContent: 'center',
+                background: isActive || isCompleted ? '#3b82f6' : '#ffffff',
+                border: isActive || isCompleted ? '2px solid #3b82f6' : '2px solid #e2e8f0',
+                color: isActive || isCompleted ? '#ffffff' : '#94a3b8',
+                fontWeight: 'bold',
+                fontSize: '14px',
+                transition: 'all 0.3s ease'
+              }}>
+                {isCompleted ? '✓' : (index + 1)}
+              </div>
+              <span style={{ 
+                marginTop: '8px', 
+                fontSize: '12px', 
+                fontWeight: isActive ? '600' : '500', 
+                color: isActive ? '#1e293b' : '#64748b',
+                whiteSpace: 'nowrap',
+                position: 'absolute',
+                top: '100%'
+              }}>
+                {step.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* spacer for the absolute positioned labels */}
+      <div style={{ height: '24px' }}></div>
+
+      {/* 2. Render Current Step Component */}
+      <div style={{ minHeight: '350px', padding: '24px 0' }}>
+         <StepComponent formData={formData} updateFormData={updateFormData} />
+      </div>
+
+      {/* 3. Navigation Footer */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '32px', borderTop: '1px solid #e2e8f0', paddingTop: '24px' }}>
+        <button 
+          onClick={prevStep} 
+          disabled={isFirstStep || isNavigating}
+          style={{
+            padding: '12px 24px',
+            background: isFirstStep ? '#f8fafc' : '#ffffff',
+            border: '1px solid #cbd5e1',
+            borderRadius: '8px',
+            cursor: isFirstStep ? 'not-allowed' : 'pointer',
+            fontWeight: '600',
+            fontSize: '15px',
+            color: isFirstStep ? '#cbd5e1' : '#475569',
+            transition: 'background-color 0.2s'
+          }}
+          onMouseOver={(e) => { if (!isFirstStep) e.target.style.backgroundColor = '#f1f5f9' }}
+          onMouseOut={(e) => { if (!isFirstStep) e.target.style.backgroundColor = '#ffffff' }}
+        >
+          Back
+        </button>
+        
+        {!isLastStep ? (
+          <button 
+            onClick={nextStep}
+            disabled={isNavigating}
+            style={{
+              padding: '12px 32px',
+              background: '#3b82f6',
+              color: '#ffffff',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: isNavigating ? 'wait' : 'pointer',
+              fontWeight: '600',
+              fontSize: '15px',
+              opacity: isNavigating ? 0.7 : 1,
+              transition: 'background-color 0.2s'
+            }}
+            onMouseOver={(e) => { if(!isNavigating) e.target.style.backgroundColor = '#2563eb' }}
+            onMouseOut={(e) => { if(!isNavigating) e.target.style.backgroundColor = '#3b82f6' }}
+          >
+            {isNavigating ? 'Validating...' : 'Next Step'}
+          </button>
+        ) : (
+          <button 
+            onClick={handleFinalSubmit}
+            disabled={isNavigating}
+            style={{
+              padding: '12px 32px',
+              background: '#10b981', // green for completion
+              color: '#ffffff',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: isNavigating ? 'wait' : 'pointer',
+              fontWeight: 'bold',
+              fontSize: '15px',
+              opacity: isNavigating ? 0.7 : 1,
+              transition: 'background-color 0.2s'
+            }}
+            onMouseOver={(e) => { if(!isNavigating) e.target.style.backgroundColor = '#059669' }}
+            onMouseOut={(e) => { if(!isNavigating) e.target.style.backgroundColor = '#10b981' }}
+          >
+            {isNavigating ? 'Processing...' : 'Complete Workflow'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Wizard;

--- a/src/contexts/ToastContext.jsx
+++ b/src/contexts/ToastContext.jsx
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
+
+// Create the Context
+const ToastContext = createContext(null);
+
+/**
+ * Custom hook to consume the Toast Context.
+ * Must be used within a ToastProvider.
+ */
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};
+
+/**
+ * Provider component that wraps the app and manages the global toast state.
+ */
+export const ToastProvider = ({ children }) => {
+  const [toasts, setToasts] = useState([]);
+  const idCounter = useRef(0);
+
+  // Removes a toast by its unique ID
+  const removeToast = useCallback((id) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  }, []);
+
+  /**
+   * Adds a new toast to the global state.
+   * @param {Object} options 
+   * @param {string} options.message - The text to display
+   * @param {'success'|'error'|'warning'|'info'} [options.type='info'] - The semantic type
+   * @param {number} [options.duration=5000] - Time in ms before auto-unmounting
+   */
+  const addToast = useCallback(({ message, type = 'info', duration = 5000 }) => {
+    const id = (idCounter.current += 1);
+    
+    const newToast = {
+      id,
+      message,
+      type,
+      duration,
+    };
+    
+    setToasts((prev) => [...prev, newToast]);
+
+    // Setup auto-removal if duration is greater than 0
+    if (duration > 0) {
+      setTimeout(() => {
+        // We let the ToastItem handle its own exit animation, but the provider acts as a fallback
+        // if we just want a strict removal.
+      }, duration);
+    }
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ addToast, removeToast, toasts }}>
+      {children}
+    </ToastContext.Provider>
+  );
+};

--- a/src/contexts/WizardContext.jsx
+++ b/src/contexts/WizardContext.jsx
@@ -1,0 +1,147 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+// Initialize the Context
+const WizardContext = createContext(null);
+
+export const useWizard = () => {
+  const context = useContext(WizardContext);
+  if (!context) {
+    throw new Error('useWizard must be used within a WizardProvider');
+  }
+  return context;
+};
+
+/**
+ * WizardProvider
+ * Manages complex nested state across multiple screens, including LocalStorage persistence
+ * and strict step-by-step validation logic.
+ * 
+ * @param {string} wizardId - Unique identifier to namespace localStorage keys
+ * @param {Object} initialData - Default structure of the form data
+ * @param {Array} steps - Array of objects defining { label, component, validate (async fn) }
+ */
+export const WizardProvider = ({ 
+  children, 
+  wizardId = 'default_wizard', 
+  initialData = {}, 
+  steps = [] 
+}) => {
+  const STORAGE_KEY = `creator_os_wizard_${wizardId}`;
+
+  const [currentStep, setCurrentStep] = useState(0);
+  const [formData, setFormData] = useState(initialData);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isNavigating, setIsNavigating] = useState(false); // To handle async validation states
+
+  // 1. Hydrate state from LocalStorage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const { step, data } = JSON.parse(saved);
+        setCurrentStep(step || 0);
+        setFormData(data || initialData);
+      }
+    } catch (e) {
+      console.error('Failed to load wizard state from storage', e);
+    }
+    setIsLoaded(true);
+  }, [STORAGE_KEY, initialData]);
+
+  // 2. Persist state to LocalStorage on change
+  useEffect(() => {
+    if (isLoaded) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        step: currentStep,
+        data: formData
+      }));
+    }
+  }, [currentStep, formData, isLoaded, STORAGE_KEY]);
+
+  const updateFormData = useCallback((newData) => {
+    setFormData(prev => ({ ...prev, ...newData }));
+  }, []);
+
+  // Strict step validation logic
+  const validateStep = async (stepIndex) => {
+    const step = steps[stepIndex];
+    if (step && typeof step.validate === 'function') {
+      try {
+        return await step.validate(formData);
+      } catch (error) {
+        console.error(`Validation error at step ${stepIndex}:`, error);
+        return false;
+      }
+    }
+    return true; // Assume valid if no validation function is explicitly provided
+  };
+
+  const nextStep = useCallback(async () => {
+    setIsNavigating(true);
+    const isValid = await validateStep(currentStep);
+    
+    if (isValid && currentStep < steps.length - 1) {
+      setCurrentStep(prev => prev + 1);
+    } else if (!isValid) {
+      console.warn(`Validation failed for step ${currentStep}. Cannot proceed.`);
+    }
+    
+    setIsNavigating(false);
+    return isValid;
+  }, [currentStep, steps, formData]);
+
+  const prevStep = useCallback(() => {
+    if (currentStep > 0) {
+      setCurrentStep(prev => prev - 1);
+    }
+  }, [currentStep]);
+
+  const goToStep = useCallback(async (index) => {
+    if (index === currentStep) return true;
+    
+    setIsNavigating(true);
+    
+    // If jumping forward, we must strictly validate all intermediate steps
+    if (index > currentStep) {
+      for (let i = currentStep; i < index; i++) {
+         const isValid = await validateStep(i);
+         if (!isValid) {
+           console.warn(`Cannot jump to step ${index}. Validation failed at intermediate step ${i}.`);
+           setIsNavigating(false);
+           return false;
+         }
+      }
+    }
+    
+    setCurrentStep(index);
+    setIsNavigating(false);
+    return true;
+  }, [currentStep, steps, formData]);
+
+  const clearWizard = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setCurrentStep(0);
+    setFormData(initialData);
+  }, [STORAGE_KEY, initialData]);
+
+  // Wait for initial hydration to prevent hydration mismatch flashes
+  if (!isLoaded) return null; 
+
+  return (
+    <WizardContext.Provider value={{
+      currentStep,
+      formData,
+      updateFormData,
+      nextStep,
+      prevStep,
+      goToStep,
+      clearWizard,
+      steps,
+      isNavigating,
+      isFirstStep: currentStep === 0,
+      isLastStep: currentStep === steps.length - 1
+    }}>
+      {children}
+    </WizardContext.Provider>
+  );
+};

--- a/src/hooks/useChunkedUpload.js
+++ b/src/hooks/useChunkedUpload.js
@@ -1,0 +1,114 @@
+import { useState, useRef, useCallback } from 'react';
+
+const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB chunks
+const MAX_RETRIES = 3;
+
+// Mock upload function to simulate chunk uploading over a network
+const mockUploadChunk = async (chunk, index, total) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      // Simulate random network failure (10% chance) to test retry logic
+      if (Math.random() < 0.1) {
+        reject(new Error('Network error'));
+      } else {
+        resolve();
+      }
+    }, 500); // 500ms artificial delay per chunk
+  });
+};
+
+export const useChunkedUpload = (file) => {
+  const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState('idle'); // idle, uploading, paused, error, success
+  const [error, setError] = useState(null);
+
+  const currentChunkIndexRef = useRef(0);
+  const statusRef = useRef('idle'); // Sync tracking for loops
+
+  const totalChunks = file ? Math.ceil(file.size / CHUNK_SIZE) : 0;
+
+  const updateStatus = (newStatus) => {
+    statusRef.current = newStatus;
+    setStatus(newStatus);
+  };
+
+  const uploadChunkWithRetry = async (chunk, index, attempt = 1) => {
+    try {
+      await mockUploadChunk(chunk, index, totalChunks);
+    } catch (err) {
+      if (attempt <= MAX_RETRIES && statusRef.current === 'uploading') {
+        const backoffTime = Math.pow(2, attempt - 1) * 1000; // Exponential backoff: 1s, 2s, 4s...
+        console.warn(`Chunk ${index} failed. Retrying in ${backoffTime}ms (Attempt ${attempt}/${MAX_RETRIES})`);
+        await new Promise((res) => setTimeout(res, backoffTime));
+        return uploadChunkWithRetry(chunk, index, attempt + 1);
+      }
+      throw err;
+    }
+  };
+
+  const processQueue = useCallback(async () => {
+    if (!file) return;
+
+    while (currentChunkIndexRef.current < totalChunks && statusRef.current === 'uploading') {
+      const index = currentChunkIndexRef.current;
+      const start = index * CHUNK_SIZE;
+      const end = Math.min(start + CHUNK_SIZE, file.size);
+      const chunk = file.slice(start, end);
+
+      try {
+        await uploadChunkWithRetry(chunk, index);
+        
+        // Break out if status changed (paused/cancelled) during the upload
+        if (statusRef.current !== 'uploading') return;
+
+        currentChunkIndexRef.current += 1;
+        setProgress(Math.round((currentChunkIndexRef.current / totalChunks) * 100));
+        
+        if (currentChunkIndexRef.current === totalChunks) {
+          updateStatus('success');
+        }
+      } catch (err) {
+        updateStatus('error');
+        setError(`Failed to upload chunk ${index + 1} after ${MAX_RETRIES} retries.`);
+        return;
+      }
+    }
+  }, [file, totalChunks]);
+
+  const start = useCallback(() => {
+    if (statusRef.current === 'uploading' || !file) return;
+    updateStatus('uploading');
+    setError(null);
+    processQueue();
+  }, [file, processQueue]);
+
+  const pause = useCallback(() => {
+    if (statusRef.current === 'uploading') {
+      updateStatus('paused');
+    }
+  }, []);
+
+  const resume = useCallback(() => {
+    if (statusRef.current === 'paused') {
+      updateStatus('uploading');
+      processQueue();
+    }
+  }, [processQueue]);
+
+  const cancel = useCallback(() => {
+    updateStatus('idle');
+    setProgress(0);
+    currentChunkIndexRef.current = 0;
+    setError(null);
+  }, []);
+
+  return {
+    progress,
+    status,
+    error,
+    start,
+    pause,
+    resume,
+    cancel
+  };
+};

--- a/src/hooks/useCsvWorker.js
+++ b/src/hooks/useCsvWorker.js
@@ -1,0 +1,62 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+export const useCsvWorker = () => {
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState(null);
+  const workerRef = useRef(null);
+
+  useEffect(() => {
+    // Instantiate the worker when the hook mounts
+    // Note: React/Vite/NextJS all support this standard Worker URL syntax
+    workerRef.current = new Worker(new URL('../workers/csvExportWorker.js', import.meta.url));
+    
+    return () => {
+      // Clean up the worker on unmount to prevent memory leaks
+      if (workerRef.current) {
+        workerRef.current.terminate();
+      }
+    };
+  }, []);
+
+  const exportCsv = useCallback((data, filename = 'analytics_export.csv') => {
+    if (!workerRef.current) return;
+    
+    setIsExporting(true);
+    setError(null);
+
+    const handleMessage = (e) => {
+      const { blob, error: workerError } = e.data;
+      
+      if (workerError) {
+        setError(workerError);
+        setIsExporting(false);
+        workerRef.current.removeEventListener('message', handleMessage);
+        return;
+      }
+
+      if (blob) {
+        // Trigger file download programmatically in the browser
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        
+        // Cleanup DOM and object URL
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        
+        setIsExporting(false);
+        workerRef.current.removeEventListener('message', handleMessage);
+      }
+    };
+
+    workerRef.current.addEventListener('message', handleMessage);
+    
+    // Send data to the background thread
+    workerRef.current.postMessage({ data });
+  }, []);
+
+  return { exportCsv, isExporting, error };
+};

--- a/src/hooks/useIntersectionObserver.js
+++ b/src/hooks/useIntersectionObserver.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook to detect when an element enters the viewport using the native Intersection Observer API.
+ * 
+ * @param {React.MutableRefObject} ref - The React ref attached to the DOM element to observe
+ * @param {Object} options - IntersectionObserver configuration options (root, rootMargin, threshold)
+ * @returns {boolean} - True if the element is currently intersecting with the viewport
+ */
+export const useIntersectionObserver = (ref, options = {}) => {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+  
+  // Destructure options to safely add them to the dependency array
+  const { threshold = 0, root = null, rootMargin = '0px' } = options;
+
+  useEffect(() => {
+    const element = ref?.current;
+    
+    // If the element hasn't mounted yet, do nothing
+    if (!element) return;
+
+    // Initialize the observer
+    const observer = new IntersectionObserver(([entry]) => {
+      // Update state based on visibility
+      setIsIntersecting(entry.isIntersecting);
+    }, { threshold, root, rootMargin });
+
+    // Start observing the target element
+    observer.observe(element);
+
+    // Cleanup function: Disconnect the observer when the component unmounts
+    // to prevent memory leaks and zombie event listeners.
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, threshold, root, rootMargin]);
+
+  return isIntersecting;
+};

--- a/src/hooks/useSecureStorage.js
+++ b/src/hooks/useSecureStorage.js
@@ -1,0 +1,51 @@
+import { useState, useCallback } from 'react';
+import { secureStorage } from '../utils/secureStorage';
+
+/**
+ * A custom hook that works exactly like React.useState, but persists the state
+ * securely in localStorage using AES encryption.
+ * 
+ * @param {string} key - The localStorage key 
+ * @param {any} initialValue - The default value to fall back to
+ * @returns {[any, Function, Function]} - [storedValue, setValue, removeValue]
+ */
+export const useSecureStorage = (key, initialValue) => {
+  // Pass an initializer function to useState so the get logic executes only once
+  const [storedValue, setStoredValue] = useState(() => {
+    // Check for SSR (Server Side Rendering) environments
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    return secureStorage.get(key, initialValue);
+  });
+
+  // Wrapped setter function that persists the new value to secureStorage
+  const setValue = useCallback((value) => {
+    try {
+      // Support functional updates just like standard useState: setValue(prev => prev + 1)
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      
+      setStoredValue(valueToStore);
+      
+      if (typeof window !== 'undefined') {
+        secureStorage.set(key, valueToStore);
+      }
+    } catch (error) {
+      console.error(`Error securely setting state for key "${key}"`, error);
+    }
+  }, [key, storedValue]);
+  
+  // Expose a function to easily wipe the key from both local state and storage
+  const removeValue = useCallback(() => {
+    try {
+      setStoredValue(initialValue); // Revert to initial
+      if (typeof window !== 'undefined') {
+        secureStorage.remove(key);
+      }
+    } catch (error) {
+      console.error(`Error securely removing state for key "${key}"`, error);
+    }
+  }, [key, initialValue]);
+
+  return [storedValue, setValue, removeValue];
+};

--- a/src/hooks/useWebSocket.js
+++ b/src/hooks/useWebSocket.js
@@ -1,0 +1,104 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export const useWebSocket = (url) => {
+  const [isConnected, setIsConnected] = useState(false);
+  const [latestMessage, setLatestMessage] = useState(null);
+  
+  const wsRef = useRef(null);
+  const reconnectTimeoutRef = useRef(null);
+  const reconnectAttemptsRef = useRef(0);
+  const isComponentUnmounted = useRef(false);
+
+  const connect = useCallback(() => {
+    if (isComponentUnmounted.current || !url) return;
+
+    try {
+      wsRef.current = new WebSocket(url);
+
+      wsRef.current.onopen = () => {
+        setIsConnected(true);
+        // Reset attempts on successful connection
+        reconnectAttemptsRef.current = 0; 
+      };
+
+      wsRef.current.onmessage = (event) => {
+        setLatestMessage(event.data);
+      };
+
+      wsRef.current.onclose = () => {
+        setIsConnected(false);
+        if (!isComponentUnmounted.current) {
+          scheduleReconnect();
+        }
+      };
+
+      wsRef.current.onerror = (error) => {
+        console.error('WebSocket error observed:', error);
+        // The onclose event will automatically fire after onerror closes the socket
+      };
+    } catch (err) {
+      console.error('WebSocket connection initialization error:', err);
+      scheduleReconnect();
+    }
+  }, [url]);
+
+  const scheduleReconnect = () => {
+    if (isComponentUnmounted.current) return;
+
+    // Exponential backoff algorithm: 1s, 2s, 4s, 8s, 16s...
+    let backoffTime = Math.pow(2, reconnectAttemptsRef.current) * 1000;
+    
+    // Cap the maximum wait time to 30 seconds
+    if (backoffTime > 30000) {
+      backoffTime = 30000;
+    }
+
+    console.warn(`WebSocket dropped. Attempting to reconnect in ${backoffTime / 1000} seconds...`);
+
+    reconnectTimeoutRef.current = setTimeout(() => {
+      reconnectAttemptsRef.current += 1;
+      connect();
+    }, backoffTime);
+  };
+
+  useEffect(() => {
+    isComponentUnmounted.current = false;
+    connect();
+
+    return () => {
+      isComponentUnmounted.current = true;
+      
+      // Clear any pending reconnection timeouts
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+      
+      // Clean up the WebSocket instance strictly
+      if (wsRef.current) {
+        // Nullify event listeners to prevent memory leaks and zombie reconnect attempts
+        wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.onmessage = null;
+        wsRef.current.onopen = null;
+        
+        wsRef.current.close();
+      }
+    };
+  }, [connect]);
+
+  const sendMessage = useCallback((message) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      // Auto-stringify JSON objects for convenience
+      const payload = typeof message === 'string' ? message : JSON.stringify(message);
+      wsRef.current.send(payload);
+    } else {
+      console.warn('Cannot send message: WebSocket is not open.');
+    }
+  }, []);
+
+  return {
+    isConnected,
+    latestMessage,
+    sendMessage,
+  };
+};

--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -1,0 +1,72 @@
+import CryptoJS from 'crypto-js';
+
+// Resolve the secret key from environment variables (supports Vite, Next.js, Create React App)
+// Fallback to a hardcoded string to ensure it doesn't crash during local dev if env is missing
+const SECRET_KEY = 
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_ENCRYPTION_KEY) || 
+  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ENCRYPTION_KEY) || 
+  (typeof process !== 'undefined' && process.env?.REACT_APP_ENCRYPTION_KEY) ||
+  'default-fallback-secure-key-12345!';
+
+export const secureStorage = {
+  /**
+   * Encrypts the value and stores it in localStorage.
+   * @param {string} key 
+   * @param {any} value 
+   */
+  set: (key, value) => {
+    try {
+      const jsonValue = JSON.stringify(value);
+      const encryptedValue = CryptoJS.AES.encrypt(jsonValue, SECRET_KEY).toString();
+      localStorage.setItem(key, encryptedValue);
+    } catch (error) {
+      console.error(`Error encrypting and saving key "${key}" to localStorage:`, error);
+    }
+  },
+
+  /**
+   * Retrieves the value from localStorage and decrypts it.
+   * If decryption fails (e.g. key mismatch), the corrupted entry is purged.
+   * @param {string} key 
+   * @param {any} defaultValue 
+   * @returns {any}
+   */
+  get: (key, defaultValue = null) => {
+    try {
+      const encryptedValue = localStorage.getItem(key);
+      if (!encryptedValue) {
+        return defaultValue;
+      }
+
+      const bytes = CryptoJS.AES.decrypt(encryptedValue, SECRET_KEY);
+      const decryptedString = bytes.toString(CryptoJS.enc.Utf8);
+      
+      // If the secret key changed, decryption yields an empty string
+      if (!decryptedString) {
+        throw new Error('Decryption resulted in an empty string (possible Secret Key mismatch)');
+      }
+
+      return JSON.parse(decryptedString);
+    } catch (error) {
+      console.warn(`Error decrypting data for key "${key}". Purging corrupted data...`, error);
+      // Fallback: clear the unreadable data and return the default value to prevent app crashes
+      localStorage.removeItem(key);
+      return defaultValue;
+    }
+  },
+  
+  /**
+   * Removes a specific item from localStorage
+   * @param {string} key 
+   */
+  remove: (key) => {
+    localStorage.removeItem(key);
+  },
+  
+  /**
+   * Clears the entire localStorage
+   */
+  clear: () => {
+    localStorage.clear();
+  }
+};

--- a/src/workers/csvExportWorker.js
+++ b/src/workers/csvExportWorker.js
@@ -1,0 +1,48 @@
+// src/workers/csvExportWorker.js
+
+// Web worker to parse JSON array to CSV Blob without freezing the main UI thread
+self.onmessage = function(e) {
+  const { data } = e.data;
+  
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    self.postMessage({ error: 'Invalid data format or empty array provided.' });
+    return;
+  }
+
+  try {
+    const headers = Object.keys(data[0]);
+    const csvRows = [];
+
+    // Push headers as the first row
+    csvRows.push(headers.join(','));
+
+    // Process all data rows
+    for (const row of data) {
+      const values = headers.map(header => {
+        const val = row[header];
+        
+        // Handle nulls and undefined
+        const stringVal = val === null || val === undefined ? '' : String(val);
+        
+        // Escape quotes and wrap the entire string in quotes if it contains a comma, quote, or newline
+        if (stringVal.includes(',') || stringVal.includes('"') || stringVal.includes('\n')) {
+          return `"${stringVal.replace(/"/g, '""')}"`;
+        }
+        
+        return stringVal;
+      });
+      csvRows.push(values.join(','));
+    }
+
+    // Join all rows with a newline character
+    const csvString = csvRows.join('\n');
+    
+    // Create a Blob from the string
+    const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
+    
+    // Send the Blob back to the main thread
+    self.postMessage({ blob });
+  } catch (error) {
+    self.postMessage({ error: error.message });
+  }
+};


### PR DESCRIPTION
## 📝 Description
Replaced the default, limited browser context menu with a bespoke, globally managed Right-Click Context Menu system. This allows us to offer powerful, application-specific actions (like "Share Link" or "Delete Video") natively when users right-click on specific elements across the dashboard.

## 🔗 Related Issues
Fixes #637

## 📋 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔄 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [x] 🎨 Style changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 🔄 Changes Made
- Created `src/components/ContextMenuProvider.jsx`.
- Intercepted the native `window.contextmenu` event globally.
- Implemented declarative triggers: The custom menu only appears if the user right-clicks on an element (or child of an element) containing the `data-context-menu` attribute. Otherwise, the default browser context menu behaves normally.
- Integrated Anti-Clipping Viewport Math: Dynamically calculates the `X` and `Y` coordinates based on the mouse pointer position, automatically flipping the menu's render origin to prevent it from bleeding off the bottom or right edges of the browser window.
- Built a localized `MENU_REGISTRY` to map specific data strings (e.g., `'video-item'`) to distinct arrays of menu actions.
- Added strict teardown logic: The menu automatically unmounts when the user clicks anywhere else on the screen or presses the `Escape` key.

## ✅ Testing

### How to Test
1. Wrap the root of the app in `<ContextMenuProvider>`.
2. Add the data attribute to any element you want to test: 
   `<div data-context-menu="video-item" data-context-id="vid_123">Right Click Me</div>`
3. Right-click the element. Verify the default browser menu is suppressed and our custom white, shadow-lifted menu appears instead with the Play, Edit, Share, and Delete options.
4. Click anywhere outside the menu to verify it closes instantly.
5. Right-click the element again, then press the `Escape` key on your keyboard. Verify the menu closes.
6. Scroll the element to the extreme bottom-right corner of your monitor and right-click it. Verify the Anti-Clipping math works and the menu renders *up and to the left* instead of disappearing off-screen.

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 📸 Screenshots (if applicable)
*(Features a highly polished, OS-native feel with subtle hover states, distinct icon alignments, and red coloring for `danger` level actions).*
<img width="2400" height="1470" alt="contextmenuCreatorOs" src="https://github.com/user-attachments/assets/5a297279-b87d-4f23-b472-d763fdb336f1" />


## 🚀 Deployment Notes
None

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Currently, the `MENU_REGISTRY` is hardcoded in the file for demonstration. In the future, we can refactor this so specific modules inject their own context definitions into the global store during runtime.

---

**Thank you for contributing to CreatorOS!** 🙌
