### PR TITLE
fix(auth): enforce email verification before login

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -297,9 +297,7 @@ const login = asyncHandler(async (req, res, next) => {
         return res.status(401).json({ success: false, message: GENERIC_LOGIN_ERROR });
     }
 
-    const isProduction = process.env.NODE_ENV === "production";
-
-    if (isProduction && user.authProvider !== "google" && !user.isVerified) {
+    if (user.authProvider !== "google" && !user.isVerified) {
         const verificationDeliveryUnavailable = !isEmailTransportConfigured();
 
         if (verificationDeliveryUnavailable && allowUnverifiedLogin) {


### PR DESCRIPTION
## Summary
- enforce email verification for local accounts before login in every environment
- keep the existing resend-verification redirect and unavailable-delivery fallback intact
- rely on the current auth endpoint coverage for verified, unverified, and fallback login flows

## Why
Issue #596 prioritizes foundation work around authentication and core flows. The login controller only blocked unverified local users in production, which made the verification flow inconsistent in test and local environments and allowed unverified accounts through outside production.

Refs #596

## Testing
- npm test -- tests/controllers/auth.test.js --runInBand --forceExit
- npm run build