### PR TITLE
fix(auth): use contributor login validator

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -13,6 +13,8 @@ const loginSchema = z.object({
   allowUnverifiedLogin: z.string().optional(),
 });
 
+const contributorLoginSchema = z.object({}).passthrough();
+
 const resendVerificationSchema = z.object({
   email: z.string().email('Invalid email format'),
 });
@@ -88,6 +90,7 @@ function validate(schema, source = 'body', viewName, buildLocals = () => ({})) {
 module.exports = { 
     signupSchema, 
     loginSchema, 
+    contributorLoginSchema,
     resendVerificationSchema,
     collaborationInviteSchema,
     collaborationAcceptSchema,
@@ -102,6 +105,7 @@ module.exports = {
     loginValidator: validate(loginSchema, 'body', 'login', () => ({
         googleAuthConfigured: Boolean(process.env.GOOGLE_CLIENT_ID)
     })),
+    contributorLoginValidator: validate(contributorLoginSchema, 'body'),
     resendVerificationValidator: validate(resendVerificationSchema, 'body', 'resend-verification'),
     shortenUrlValidator: validate(urlShortenSchema, 'body'),
     updateQrColorsValidator: validate(urlQRColorsSchema, 'body'),

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,7 +2,7 @@ const express = require("express");
 const passport = require("passport");
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const { signup, login, handleGoogleCallback, loginAsContributor, verifyEmail, resendVerificationEmail, requestPasswordReset, resetPassword } = require("../controller/auth");
-const { signupValidator, loginValidator, resendVerificationValidator } = require("../middleware/validators");
+const { signupValidator, loginValidator, contributorLoginValidator, resendVerificationValidator } = require("../middleware/validators");
 const connectDB = require("../connect");
 const { loginLimiter, signupLimiter, emailVerificationLimiter, forgotPasswordLimiter } = require("../middleware/rateLimiters");
 
@@ -176,7 +176,7 @@ router.post("/login", loginLimiter, loginValidator, login);
  *       500:
  *         description: Internal server error
  */
-router.post("/login/contributor", loginLimiter, loginValidator, loginAsContributor);
+router.post("/login/contributor", loginLimiter, contributorLoginValidator, loginAsContributor);
 
 /**
  * @swagger
@@ -194,7 +194,7 @@ router.post("/login/contributor", loginLimiter, loginValidator, loginAsContribut
  *       500:
  *         description: Internal server error
  */
-router.post("/api/auth/contributor-login", loginLimiter, loginValidator, loginAsContributor);
+router.post("/api/auth/contributor-login", loginLimiter, contributorLoginValidator, loginAsContributor);
 
 
 /**

--- a/tests/routes/contributorLoginValidator.test.js
+++ b/tests/routes/contributorLoginValidator.test.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../controller/auth', () => ({
+    signup: jest.fn(),
+    login: jest.fn(),
+    handleGoogleCallback: jest.fn(),
+    loginAsContributor: jest.fn((req, res) => res.status(200).json({ success: true })),
+    verifyEmail: jest.fn(),
+    resendVerificationEmail: jest.fn(),
+    requestPasswordReset: jest.fn(),
+    resetPassword: jest.fn(),
+}));
+
+jest.mock('../../middleware/rateLimiters', () => ({
+    loginLimiter: (req, res, next) => next(),
+    signupLimiter: (req, res, next) => next(),
+    emailVerificationLimiter: (req, res, next) => next(),
+    forgotPasswordLimiter: (req, res, next) => next(),
+}));
+
+jest.mock('../../connect', () => jest.fn());
+
+describe('contributor login routes', () => {
+    let app;
+
+    beforeEach(() => {
+        jest.resetModules();
+        app = express();
+        app.use(express.json());
+        app.set('view engine', 'ejs');
+        app.use(require('../../routes/auth'));
+    });
+
+    test.each(['/login/contributor', '/api/auth/contributor-login'])(
+        'allows %s without creator credentials',
+        async (path) => {
+            const res = await request(app).post(path).send({});
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual({ success: true });
+        }
+    );
+});


### PR DESCRIPTION
## Summary
- add a contributor login validator that does not require creator credentials
- wire both contributor login routes to the contributor-specific validator
- add route coverage for empty contributor login requests

## Why
The contributor login controller creates a guest contributor session and does not use email/password fields. Reusing the creator login validator caused valid empty contributor login requests to fail before reaching the controller.

Fixes #664

## Testing
- npm test -- tests/routes/contributorLoginValidator.test.js --runInBand --forceExit
- npm run build