### PR TITLE
fix(auth): revoke old password reset tokens

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -629,6 +629,11 @@ const requestPasswordReset = asyncHandler(async (req, res) => {
         return res.json({ success: true, message: 'If email exists, reset link has been sent' });
     }
 
+    await PasswordResetToken.updateMany(
+        { userId: user._id, used: false },
+        { $set: { used: true, usedAt: new Date() } }
+    );
+
     // Create password reset token (15 minute validity)
     const resetToken = crypto.randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes

--- a/tests/controllers/passwordResetRevocation.test.js
+++ b/tests/controllers/passwordResetRevocation.test.js
@@ -1,0 +1,72 @@
+const mockConnectDB = jest.fn();
+const mockFindOne = jest.fn();
+const mockUpdateMany = jest.fn();
+const mockCreate = jest.fn();
+const mockSendPasswordResetEmail = jest.fn();
+
+jest.mock('../../connect', () => mockConnectDB);
+jest.mock('../../model/user', () => ({
+    findOne: mockFindOne,
+}));
+jest.mock('../../model/passwordResetToken', () => ({
+    updateMany: mockUpdateMany,
+    create: mockCreate,
+}));
+jest.mock('../../utils/email', () => ({
+    isEmailTransportConfigured: jest.fn(() => true),
+    sendPasswordResetEmail: mockSendPasswordResetEmail,
+}));
+jest.mock('../../utils/loginAttemptManager', () => ({
+    checkIfLoginLocked: jest.fn(),
+    recordFailedLoginAttempt: jest.fn(),
+    clearLoginAttempts: jest.fn(),
+    getRemainingLoginLockoutTime: jest.fn(),
+    checkIfResetLocked: jest.fn(() => false),
+    recordFailedResetAttempt: jest.fn(),
+    clearResetAttempts: jest.fn(),
+    getRemainingResetLockoutTime: jest.fn(),
+}));
+
+const { requestPasswordReset } = require('../../controller/auth');
+
+describe('requestPasswordReset token revocation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFindOne.mockResolvedValue({
+            _id: 'user-1',
+            email: 'creator@example.com',
+            name: 'Creator',
+        });
+        mockUpdateMany.mockResolvedValue({ modifiedCount: 1 });
+        mockCreate.mockResolvedValue({});
+        mockSendPasswordResetEmail.mockResolvedValue();
+    });
+
+    test('revokes existing unused reset tokens before creating a new one', async () => {
+        const req = {
+            body: { email: ' Creator@Example.com ' },
+            protocol: 'https',
+            get: jest.fn((header) => header === 'host' ? 'app.test' : 'jest'),
+            ip: '127.0.0.1',
+        };
+        const res = {
+            json: jest.fn(),
+            status: jest.fn().mockReturnThis(),
+        };
+
+        await requestPasswordReset(req, res, jest.fn());
+
+        expect(mockUpdateMany).toHaveBeenCalledWith(
+            { userId: 'user-1', used: false },
+            {
+                $set: {
+                    used: true,
+                    usedAt: expect.any(Date),
+                },
+            }
+        );
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+        expect(mockUpdateMany.mock.invocationCallOrder[0]).toBeLessThan(mockCreate.mock.invocationCallOrder[0]);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    });
+});


### PR DESCRIPTION
## Summary
- mark existing unused reset tokens as used before issuing a new reset token
- keep the generic password reset response unchanged
- add controller coverage for revocation happening before token creation

## Why
Multiple reset requests could leave several valid tokens for the same account. Revoking older unused tokens makes the newest reset email the only usable recovery link.

Fixes #665

## Testing
- npm test -- tests/controllers/passwordResetRevocation.test.js --runInBand --forceExit
- npm run build