### PR TITLE
fix(auth): release failed reset token claims

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -25,6 +25,15 @@ const GENERIC_LOGIN_ERROR = "Invalid email or password";
 const GOOGLE_AUTH_CANCELLED_ERROR = "Google sign-in was cancelled or could not be completed.";
 const VERIFICATION_UNAVAILABLE_ERROR = "Email verification is temporarily unavailable because email delivery is not configured. Please try again later or contact support.";
 
+async function releaseClaimedResetToken(PasswordResetToken, resetTokenDoc) {
+    if (!resetTokenDoc?._id) return;
+
+    await PasswordResetToken.updateOne(
+        { _id: resetTokenDoc._id, used: true },
+        { $set: { used: false }, $unset: { usedAt: "" } }
+    );
+}
+
 /**
  * @function getUserModel
  * @description Retrieves the User model instance.
@@ -702,13 +711,19 @@ const resetPassword = asyncHandler(async (req, res) => {
     // Update user password
     const user = await User.findById(resetTokenDoc.userId);
     if (!user) {
+        await releaseClaimedResetToken(PasswordResetToken, resetTokenDoc);
         return res.status(400).json({ success: false, message: 'User not found' });
     }
 
-    const hashedPassword = await bcrypt.hash(newPassword, 10);
-    user.password = hashedPassword;
-    user.passwordChangedAt = new Date();
-    await user.save();
+    try {
+        const hashedPassword = await bcrypt.hash(newPassword, 10);
+        user.password = hashedPassword;
+        user.passwordChangedAt = new Date();
+        await user.save();
+    } catch (error) {
+        await releaseClaimedResetToken(PasswordResetToken, resetTokenDoc);
+        throw error;
+    }
 
     await clearResetAttempts(user.email);
 

--- a/tests/controllers/passwordResetClaimRollback.test.js
+++ b/tests/controllers/passwordResetClaimRollback.test.js
@@ -1,0 +1,64 @@
+const mockConnectDB = jest.fn();
+const mockFindById = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
+const mockFindOne = jest.fn();
+const mockUpdateOne = jest.fn();
+
+jest.mock('../../connect', () => mockConnectDB);
+jest.mock('../../model/user', () => ({
+    findById: mockFindById,
+}));
+jest.mock('../../model/passwordResetToken', () => ({
+    findOneAndUpdate: mockFindOneAndUpdate,
+    findOne: mockFindOne,
+    updateOne: mockUpdateOne,
+}));
+jest.mock('../../utils/email', () => ({
+    isEmailTransportConfigured: jest.fn(() => true),
+}));
+jest.mock('../../utils/loginAttemptManager', () => ({
+    checkIfLoginLocked: jest.fn(),
+    recordFailedLoginAttempt: jest.fn(),
+    clearLoginAttempts: jest.fn(),
+    getRemainingLoginLockoutTime: jest.fn(),
+    checkIfResetLocked: jest.fn(),
+    recordFailedResetAttempt: jest.fn(),
+    clearResetAttempts: jest.fn(),
+    getRemainingResetLockoutTime: jest.fn(),
+}));
+
+const { resetPassword } = require('../../controller/auth');
+
+describe('resetPassword claimed token rollback', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFindOneAndUpdate.mockResolvedValue({
+            _id: 'reset-token-1',
+            userId: 'missing-user',
+        });
+        mockFindById.mockResolvedValue(null);
+        mockUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+    });
+
+    test('releases a claimed reset token when the user cannot be found', async () => {
+        const req = {
+            body: {
+                token: 'token-1',
+                newPassword: 'Password123!',
+            },
+        };
+        const res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+
+        await resetPassword(req, res, jest.fn());
+
+        expect(mockUpdateOne).toHaveBeenCalledWith(
+            { _id: 'reset-token-1', used: true },
+            { $set: { used: false }, $unset: { usedAt: "" } }
+        );
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ success: false, message: 'User not found' });
+    });
+});


### PR DESCRIPTION
## Summary
- add a helper to release a claimed password reset token
- release the token when the associated user cannot be found
- release the token if saving the new password fails
- add controller coverage for the missing-user rollback path

## Why
The reset flow marked a token as used before the password update was guaranteed to complete. A downstream failure could burn an otherwise valid token and force the user to restart recovery.

Fixes #666

## Testing
- npm test -- tests/controllers/passwordResetClaimRollback.test.js --runInBand --forceExit
- npm run build