### PR TITLE
fix(url): preserve mock link owner

### DIFF
--- a/model/url.js
+++ b/model/url.js
@@ -93,6 +93,7 @@ class MockUrlModel {
         this.shortId = data.shortId;
         this.redirectUrl = data.redirectUrl;
         this.campaignName = data.campaignName || "Untitled Campaign";
+        this.userId = data.userId;
         this.totalClicks = data.totalClicks || 0;
         this.qrFgColor = data.qrFgColor || "#1a1a1a";
         this.qrBgColor = data.qrBgColor || "#ffffff";

--- a/tests/model/mockUrlUserId.test.js
+++ b/tests/model/mockUrlUserId.test.js
@@ -1,0 +1,47 @@
+describe('MockUrlModel user ownership', () => {
+    const originalUseMockDb = process.env.USE_MOCK_DB;
+    let Url;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env.USE_MOCK_DB = 'true';
+        Url = require('../../model/url');
+    });
+
+    afterEach(async () => {
+        await Url.deleteMany({});
+        if (originalUseMockDb === undefined) {
+            delete process.env.USE_MOCK_DB;
+        } else {
+            process.env.USE_MOCK_DB = originalUseMockDb;
+        }
+    });
+
+    test('preserves userId for mock-created links', async () => {
+        const link = await Url.create({
+            shortId: 'abc123',
+            redirectUrl: 'https://example.com',
+            userId: 'user-1',
+        });
+
+        expect(link.userId).toBe('user-1');
+    });
+
+    test('lists only links for the requested mock user', async () => {
+        await Url.create({
+            shortId: 'user-link',
+            redirectUrl: 'https://example.com/user',
+            userId: 'user-1',
+        });
+        await Url.create({
+            shortId: 'other-link',
+            redirectUrl: 'https://example.com/other',
+            userId: 'user-2',
+        });
+
+        const links = await Url.listForUser('user-1');
+
+        expect(links).toHaveLength(1);
+        expect(links[0].shortId).toBe('user-link');
+    });
+});


### PR DESCRIPTION
## Summary
- preserve `userId` when constructing mock URL records
- add tests for mock-created link ownership
- verify mock `listForUser` only returns links for the requested user

## Why
Mock DB mode dropped link ownership during creation, so user-scoped link listing and dashboard behavior diverged from the real Mongoose model.

Fixes #670

## Testing
- npm test -- tests/model/mockUrlUserId.test.js --runInBand --forceExit
- npm run build