### PR TITLE
fix(url): validate dashboard pagination cursor

### DIFF
--- a/controller/url.js
+++ b/controller/url.js
@@ -1,6 +1,7 @@
 const { nanoid } = require('nanoid');
 const shortid = require('shortid');
 const QRCode = require('qrcode');
+const mongoose = require('mongoose');
 const Url = require('../model/url');
 const { isValidUrl } = require('../utils/validators');
 const asyncHandler = require('../utils/asyncHandler');
@@ -210,6 +211,19 @@ const handleRenderDashboard = asyncHandler(async (req, res) => {
     // Prevent loading entire collection into memory on large datasets
     const pageSize = Math.min(parseInt(req.query.limit) || 20, 100); // Max 100 per page
     const cursor = req.query.cursor;
+
+    if (cursor && !mongoose.Types.ObjectId.isValid(cursor)) {
+        return res.status(400).render("home", {
+            urls: [],
+            nextCursor: null,
+            hasMore: false,
+            id: null,
+            shortUrl: null,
+            qrCode: null,
+            campaignName: "",
+            error: "Invalid pagination cursor"
+        });
+    }
 
     const userId = req.user?.id || null;
     const query = cursor ? { _id: { $lt: cursor }, userId } : { userId };

--- a/tests/controllers/dashboardCursor.test.js
+++ b/tests/controllers/dashboardCursor.test.js
@@ -1,0 +1,34 @@
+const mockFind = jest.fn();
+
+jest.mock('../../model/url', () => ({
+    find: mockFind,
+}));
+
+const { handleRenderDashboard } = require('../../controller/url');
+
+describe('handleRenderDashboard cursor validation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('renders a controlled 400 response for invalid cursors', async () => {
+        const req = {
+            query: { cursor: 'not-an-object-id' },
+            user: { id: 'user-1' },
+        };
+        const res = {
+            status: jest.fn().mockReturnThis(),
+            render: jest.fn(),
+        };
+
+        await handleRenderDashboard(req, res, jest.fn());
+
+        expect(mockFind).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.render).toHaveBeenCalledWith('home', expect.objectContaining({
+            error: 'Invalid pagination cursor',
+            urls: [],
+            hasMore: false,
+        }));
+    });
+});


### PR DESCRIPTION
## Summary
- validate dashboard pagination cursors before building Mongo queries
- render a controlled 400 state for invalid cursor input
- add controller coverage to ensure invalid cursors do not reach the Url query

## Why
The dashboard route used raw cursor values in `_id` comparisons, allowing malformed cursors to trigger CastError instead of a predictable response.

Fixes #671

## Testing
- npm test -- tests/controllers/dashboardCursor.test.js --runInBand --forceExit
- npm run build