### PR TITLE
fix(billing): restrict checkout price ids

### DIFF
--- a/controller/billing.js
+++ b/controller/billing.js
@@ -17,6 +17,10 @@ const createCheckoutSession = asyncHandler(async (req, res) => {
     }
 
     const resolvedPriceId = priceId || process.env.STRIPE_PRO_PRICE_ID;
+    if (priceId && priceId !== process.env.STRIPE_PRO_PRICE_ID) {
+        return res.status(400).json({ success: false, message: "Invalid billing plan selected" });
+    }
+
     if (!resolvedPriceId || !process.env.BASE_URL) {
         console.error("Stripe checkout misconfigured: missing STRIPE_PRO_PRICE_ID or BASE_URL");
         return res.status(500).json({ success: false, message: "Billing is not configured correctly" });

--- a/tests/controllers/billingCheckoutPrice.test.js
+++ b/tests/controllers/billingCheckoutPrice.test.js
@@ -1,0 +1,73 @@
+const mockCreateSession = jest.fn();
+
+jest.mock('stripe', () => jest.fn(() => ({
+    checkout: {
+        sessions: {
+            create: mockCreateSession,
+        },
+    },
+})), { virtual: true });
+
+jest.mock('../../model/user', () => ({}));
+
+describe('createCheckoutSession price validation', () => {
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+        process.env.STRIPE_PRO_PRICE_ID = 'price_allowed';
+        process.env.BASE_URL = 'https://app.test';
+    });
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+    });
+
+    test('rejects client supplied price ids that are not configured', async () => {
+        const { createCheckoutSession } = require('../../controller/billing');
+        const req = {
+            body: { priceId: 'price_unapproved' },
+            user: { id: 'user-1', email: 'creator@example.com' },
+        };
+        const res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+
+        await createCheckoutSession(req, res, jest.fn());
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({
+            success: false,
+            message: 'Invalid billing plan selected',
+        });
+        expect(mockCreateSession).not.toHaveBeenCalled();
+    });
+
+    test('uses the configured price id when no client price is supplied', async () => {
+        mockCreateSession.mockResolvedValue({ url: 'https://checkout.test/session' });
+        const { createCheckoutSession } = require('../../controller/billing');
+        const req = {
+            body: {},
+            user: { id: 'user-1', email: 'creator@example.com' },
+        };
+        const res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+
+        await createCheckoutSession(req, res, jest.fn());
+
+        expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+            line_items: [
+                {
+                    price: 'price_allowed',
+                    quantity: 1,
+                },
+            ],
+        }));
+        expect(res.json).toHaveBeenCalledWith({ success: true, url: 'https://checkout.test/session' });
+    });
+});


### PR DESCRIPTION
## Summary
- reject client-supplied Stripe price IDs that do not match the configured plan
- keep default checkout on the server-configured price
- add controller coverage for rejected and default checkout paths

## Why
The checkout endpoint accepted arbitrary price IDs from request bodies. Restricting checkout to configured pricing prevents clients from selecting unintended Stripe prices.

Fixes #672

## Testing
- npm test -- tests/controllers/billingCheckoutPrice.test.js --runInBand --forceExit
- npm run build