### PR TITLE
fix(billing): mount stripe webhook before json parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ const aiRoute = require("./routes/ai");
 const authRoutes = require("./routes/auth");
 const instagramRoutes = require('./routes/instagram');
 const billingRoute = require('./routes/billing');
+const { handleWebhook: handleBillingWebhook } = require('./controller/billing');
 const domainRoute = require('./routes/domain');
 const sponsorRoute = require('./routes/sponsor');
 const settingsRoutes = require('./routes/settings');
@@ -68,6 +69,7 @@ app.use(helmet({
 app.use(cors());
 app.use(cacheHeadersMiddleware);
 app.use(cookieParser());
+app.post('/api/billing/webhook', express.raw({ type: 'application/json' }), handleBillingWebhook);
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json({
     verify: (req, res, buf) => {

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { createCheckoutSession, handleWebhook } = require("../controller/billing");
+const { createCheckoutSession } = require("../controller/billing");
 const { protect } = require("../middleware/auth");
 
 const router = express.Router();
@@ -19,17 +19,5 @@ const router = express.Router();
  *         description: Unauthorized
  */
 router.post("/checkout", protect, createCheckoutSession);
-
-/**
- * @swagger
- * /api/billing/webhook:
- *   post:
- *     summary: Stripe webhook receiver
- *     description: Handles incoming Stripe events like checkout.session.completed.
- *     responses:
- *       200:
- *         description: Event received
- */
-router.post("/webhook", express.raw({ type: 'application/json' }), handleWebhook);
 
 module.exports = router;

--- a/tests/routes/billingWebhookMount.test.js
+++ b/tests/routes/billingWebhookMount.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('billing webhook mount order', () => {
+    test('mounts the raw Stripe webhook before global json parsing', () => {
+        const indexSource = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+
+        const webhookIndex = indexSource.indexOf("app.post('/api/billing/webhook', express.raw");
+        const jsonParserIndex = indexSource.indexOf('app.use(express.json');
+
+        expect(webhookIndex).toBeGreaterThan(-1);
+        expect(jsonParserIndex).toBeGreaterThan(-1);
+        expect(webhookIndex).toBeLessThan(jsonParserIndex);
+    });
+
+    test('does not remount the webhook inside the parsed billing router', () => {
+        const routeSource = fs.readFileSync(path.join(__dirname, '../../routes/billing.js'), 'utf8');
+
+        expect(routeSource).not.toContain('router.post("/webhook"');
+    });
+});


### PR DESCRIPTION
## Summary
- mount the Stripe webhook endpoint before global URL-encoded and JSON parsers
- route webhook requests directly to the billing webhook handler with `express.raw`
- remove the parsed billing-router webhook mount
- add a regression test for webhook mount order

## Why
Stripe signature verification needs the untouched request body. Mounting the webhook inside the normal billing router allowed global parsers to consume the JSON payload first.

Fixes #673

## Testing
- npm test -- tests/routes/billingWebhookMount.test.js --runInBand --forceExit
- npm run build