### PR TITLE
fix(navbar): prevent mobile navbar from shifting off-screen on scroll

### DIFF
--- a/view/services-hub.ejs
+++ b/view/services-hub.ejs
@@ -43,17 +43,11 @@
 
 
 .footer-ticker {
-
   background: #1a1a1a;
-
   padding: 11px 0;
-
   overflow: hidden;
-
   border-bottom: 2.5px solid #1a1a1a;
-
 }
-
 
 
 .footer-ticker-inner {
@@ -2146,7 +2140,7 @@ footer span { color: var(--cyan); }
 
   /* mobile: make navbar full-width while keeping glass look */
 
-  nav { left: 12px; right: 12px; transform: none; width: auto; top: 12px; border-radius: 10px; }
+  nav, nav.scrolled { left: 12px; right: 12px; transform: none; width: auto; top: 12px; border-radius: 10px; }
 
   .brand { gap: 0.68rem; }
 


### PR DESCRIPTION
## 📝 Description
Fixes the mobile navbar becoming half-visible/cut off on the left side after scrolling. The bug occurred because the `.scrolled` class (toggled via JS past 50px scroll) applied the desktop `translateX(-50%)` centering transform, which conflicted with the mobile-only `left/right: 12px` positioning — shifting the navbar half its width off-screen.

## 🔗 Related Issues
Fixes #117

## 📋 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔄 Changes Made
- Added an override for `nav.scrolled` inside the `@media (max-width: 900px)` block so it inherits the mobile `left/right: 12px; transform: none` positioning instead of the desktop centering transform
- No JS changes needed — the scroll-triggered `.scrolled` class toggle logic was already correct; only the CSS cascade was missing a mobile override

## ✅ Testing
### How to Test
1. Open the site on a mobile viewport (or Chrome DevTools mobile emulation) at width ≤ 900px
2. Scroll down past ~50px so the `.scrolled` class is applied to the navbar
3. Confirm the navbar stays anchored with equal spacing on both sides and doesn't shift left/off-screen

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)

## 🚀 Deployment Notes
None — pure CSS fix, no schema, API, or JS behavior changes.

## ⚠️ Breaking Changes
- None

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My PR title follows the naming convention
- [x] I have linked related issues

## 📝 Additional Context
Root cause: `nav.scrolled { transform: translateX(-50%) translateY(-2px); }` is defined once, outside any media query, for the desktop centered-navbar layout. The mobile media query overrode base `nav` positioning but not `nav.scrolled`, so once scrolled, the desktop transform silently took over on mobile too.