### PR TITLE
fix(auth): remove duplicate login limiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,15 +119,6 @@ app.use((req, res, next) => {
     next();
 });
 
-const rateLimit = require('express-rate-limit');
-
-const loginLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 15,
-    message: 'Too many login attempts, please try again later.'
-});
-app.post('/login', loginLimiter);
-
 const uploadLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     max: 10,
@@ -144,6 +135,7 @@ app.use("/", authRoutes);
 
 const { protect } = require("./middleware/auth");
 const { preventContributorWrites } = require("./middleware/auth");
+const rateLimit = require('express-rate-limit');
 
 const fs = require('fs');
 app.use(express.static(path.join(__dirname, 'public')));

--- a/tests/routes/loginLimiterMount.test.js
+++ b/tests/routes/loginLimiterMount.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('login limiter mounting', () => {
+    test('does not register a duplicate app-level POST /login limiter', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+
+        expect(source).not.toMatch(/app\.post\(['"]\/login['"],\s*loginLimiter\)/);
+    });
+
+    test('keeps login rate limiting on the auth route', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../../routes/auth.js'), 'utf8');
+
+        expect(source).toContain('router.post("/login", loginLimiter, loginValidator, login)');
+    });
+});


### PR DESCRIPTION
## Summary
- remove the duplicate app-level POST /login rate limiter
- keep login rate limiting on the auth route
- add coverage that guards against remounting the duplicate limiter

## Why
Login requests were passing through both the app-level limiter and the auth route limiter, causing a single attempt to consume two limiter hits.

Fixes #688

## Testing
- npm test -- tests/routes/loginLimiterMount.test.js --runInBand --forceExit
- npm run build