### PR TITLE
fix(settings): require profile update fields

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -57,6 +57,8 @@ const updateProfileSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name must be at most 100 characters').optional(),
   alias: z.string().min(1, 'Alias is required').max(50, 'Alias must be at most 50 characters').regex(/^[a-zA-Z0-9_-]+$/, 'Alias can only contain letters, numbers, hyphens and underscores').optional(),
   bio: z.string().max(500, 'Bio must be at most 500 characters').optional(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: 'At least one profile field is required',
 });
 
 const objectIdParamSchema = z.object({

--- a/tests/middleware/updateProfileSchema.test.js
+++ b/tests/middleware/updateProfileSchema.test.js
@@ -1,0 +1,17 @@
+const { updateProfileSchema } = require('../../middleware/validators');
+
+describe('updateProfileSchema', () => {
+    test('rejects empty profile update payloads', () => {
+        const result = updateProfileSchema.safeParse({});
+
+        expect(result.success).toBe(false);
+        expect(result.error.issues[0].message).toBe('At least one profile field is required');
+    });
+
+    test('accepts valid partial profile updates', () => {
+        const result = updateProfileSchema.safeParse({ bio: 'Updated creator bio' });
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ bio: 'Updated creator bio' });
+    });
+});


### PR DESCRIPTION
## Summary
- reject empty profile update payloads
- keep valid partial profile updates working
- add schema coverage for empty and one-field updates

## Why
The profile settings endpoint accepted an empty request body and returned success even though no editable field changed.

Fixes #690

## Testing
- npm test -- tests/middleware/updateProfileSchema.test.js --runInBand --forceExit
- npm run build