### PR TITLE
fix(test): apply mock user set updates

### DIFF
--- a/model/user.js
+++ b/model/user.js
@@ -243,6 +243,12 @@ class MockUserModel {
             });
         }
 
+        if (update.$set) {
+            Object.entries(update.$set).forEach(([key, value]) => {
+                user[key] = value;
+            });
+        }
+
         Object.entries(update).forEach(([key, value]) => {
             if (!key.startsWith("$")) user[key] = value;
         });

--- a/tests/model/mockUserSetUpdate.test.js
+++ b/tests/model/mockUserSetUpdate.test.js
@@ -1,0 +1,37 @@
+describe('MockUserModel findByIdAndUpdate operators', () => {
+    const originalUseMockDb = process.env.USE_MOCK_DB;
+    let User;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env.USE_MOCK_DB = 'true';
+        User = require('../../model/user');
+    });
+
+    afterEach(async () => {
+        await User.deleteMany({ email: 'set-test@example.com' });
+        if (originalUseMockDb === undefined) {
+            delete process.env.USE_MOCK_DB;
+        } else {
+            process.env.USE_MOCK_DB = originalUseMockDb;
+        }
+    });
+
+    test('applies $set updates in mock DB mode', async () => {
+        const user = await User.create({
+            name: 'Set Test',
+            email: 'set-test@example.com',
+            password: 'hashed',
+            isVerified: true,
+        });
+
+        const updated = await User.findByIdAndUpdate(
+            user._id,
+            { $set: { name: 'Updated Name', alias: 'updated' } },
+            { new: true }
+        );
+
+        expect(updated.name).toBe('Updated Name');
+        expect(updated.alias).toBe('updated');
+    });
+});


### PR DESCRIPTION
## Summary
- add `$set` support to mock User `findByIdAndUpdate`
- preserve existing `$addToSet` and direct update behavior
- add model coverage for `$set` updates in mock DB mode

## Why
Mock DB mode ignored `$set` updates, so tests and local flows could diverge from the real Mongoose model.

Fixes #694

## Testing
- npm test -- tests/model/mockUserSetUpdate.test.js --runInBand --forceExit
- npm run build