### PR TITLE
fix(auth): trim signup display names

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -196,6 +196,7 @@ const signup = asyncHandler(async (req, res, next) => {
         return res.status(400).json({ success: false, message: "Name, email, and password are required" });
     }
 
+    const normalizedName = name.trim();
     const normalizedEmail = email.toLowerCase().trim();
 
     const existingUser = await User.findOne({ email: normalizedEmail });
@@ -212,7 +213,7 @@ const signup = asyncHandler(async (req, res, next) => {
     const verificationTokenExpiry = getVerificationTokenExpiry();
 
     const user = await User.create({
-        name,
+        name: normalizedName,
         email: normalizedEmail,
         password: hashedPassword,
         authProvider: "local",
@@ -232,7 +233,7 @@ const signup = asyncHandler(async (req, res, next) => {
             await sendVerificationEmail({
                 to: normalizedEmail,
                 verificationLink,
-                userName: name,
+                userName: normalizedName,
             });
         } else {
             verificationDeliveryUnavailable = true;

--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -2,7 +2,7 @@ const { z } = require('zod');
 const { wantsHtml } = require('../utils/requestType');
 
 const signupSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
+  name: z.string().trim().min(1, 'Name is required'),
   email: z.string().email('Invalid email format'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
 });

--- a/tests/middleware/signupSchema.test.js
+++ b/tests/middleware/signupSchema.test.js
@@ -1,0 +1,25 @@
+const { signupSchema } = require('../../middleware/validators');
+
+describe('signupSchema', () => {
+    test('rejects whitespace-only names', () => {
+        const result = signupSchema.safeParse({
+            name: '   ',
+            email: 'creator@example.com',
+            password: 'Password123!',
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error.issues[0].message).toBe('Name is required');
+    });
+
+    test('trims valid names', () => {
+        const result = signupSchema.safeParse({
+            name: '  Creator Name  ',
+            email: 'creator@example.com',
+            password: 'Password123!',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data.name).toBe('Creator Name');
+    });
+});


### PR DESCRIPTION
## Summary
- trim signup display names during validation
- reject whitespace-only signup names
- persist the normalized name and use it for verification email personalization
- add schema coverage for rejected and trimmed names

## Why
Signup only required a one-character name, allowing whitespace-only display names to be stored.

Fixes #695

## Testing
- npm test -- tests/middleware/signupSchema.test.js --runInBand --forceExit
- npm run build