### PR TITLE
fix(suggestions): trim topic input

### DIFF
--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -50,7 +50,7 @@ const urlQRColorsSchema = z.object({
 });
 
 const suggestionSchema = z.object({
-  topic: z.string().min(1, 'Topic is required'),
+  topic: z.string().trim().min(1, 'Topic is required'),
 });
 
 const updateProfileSchema = z.object({

--- a/tests/middleware/suggestionSchema.test.js
+++ b/tests/middleware/suggestionSchema.test.js
@@ -1,0 +1,17 @@
+const { suggestionSchema } = require('../../middleware/validators');
+
+describe('suggestionSchema', () => {
+    test('rejects whitespace-only topics', () => {
+        const result = suggestionSchema.safeParse({ topic: '   ' });
+
+        expect(result.success).toBe(false);
+        expect(result.error.issues[0].message).toBe('Topic is required');
+    });
+
+    test('trims valid topics', () => {
+        const result = suggestionSchema.safeParse({ topic: '  audience growth  ' });
+
+        expect(result.success).toBe(true);
+        expect(result.data.topic).toBe('audience growth');
+    });
+});


### PR DESCRIPTION
## Summary
- trim suggestion topics during validation
- reject whitespace-only topics before generation
- add schema coverage for blank and trimmed topic input

## Why
The suggestions flow accepted whitespace-only topics, which reached the generator and produced low-quality generic output.

Fixes #696

## Testing
- npm test -- tests/middleware/suggestionSchema.test.js --runInBand --forceExit
- npm run build