### PR TITLE
fix: analytics dashboard shows stale data after switching accounts

### DIFF
--- a/controller/analytics.js
+++ b/controller/analytics.js
@@ -90,4 +90,13 @@ const triggerRefresh = asyncHandler(async (req, res) => {
     res.json({ success: true, message: "Refresh successful", data: snapshot });
 });
 
-module.exports = { getSnapshots, getLatestSnapshot, triggerRefresh, getEngagementHistory };
+// GET /api/analytics/creators
+const getCreatorsByUser = asyncHandler(async (req, res) => {
+    const creators = await Creator.find({ userId: req.user.id })
+        .select('_id username platform profileUrl avatar')
+        .lean();
+
+    res.json({ success: true, data: creators });
+});
+
+module.exports = { getSnapshots, getLatestSnapshot, triggerRefresh, getEngagementHistory, getCreatorsByUser };

--- a/index.js
+++ b/index.js
@@ -715,7 +715,13 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
         const userDoc = await User.findById(req.user.id)
             .select('name email')
             .lean();
-        const creatorDoc = await Creator.findOne({ userId: req.user.id }).lean();
+        const allCreators = await Creator.find({ userId: req.user.id })
+            .select('_id username platform profileUrl avatar')
+            .lean();
+        const selectedCreatorId = req.query.creatorId || (allCreators[0] && allCreators[0]._id.toString());
+        const creatorDoc = selectedCreatorId
+            ? await Creator.findById(selectedCreatorId).lean()
+            : null;
         const analytics = creatorDoc
             ? await buildAnalyticsViewModel(creatorDoc._id)
             : { isLoading: false, isEmpty: true, metrics: [], charts: { labels: [], followers: [], engagement: [] }, topPosts: [] };
@@ -724,6 +730,8 @@ app.get('/services/:serviceKey', protect, asyncHandler(async (req, res) => {
             services,
             user: buildAccountViewModel(userDoc, req.user),
             analytics,
+            creators: allCreators,
+            selectedCreatorId: selectedCreatorId || null,
         });
     }
 

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -6,6 +6,7 @@ const {
     getLatestSnapshot,
     triggerRefresh,
     getEngagementHistory,
+    getCreatorsByUser,
 } = require("../controller/analytics");
 const { validate, objectIdParamSchema } = require("../middleware/validators");
 
@@ -17,6 +18,7 @@ const refreshLimiter = rateLimit({
     message: "Too many refresh attempts, please try again after 15 minutes.",
 });
 
+router.get("/creators", getCreatorsByUser);
 router.get("/:creatorId/snapshots", validateCreatorId, getSnapshots);
 router.get("/:creatorId/snapshots/latest", validateCreatorId, getLatestSnapshot);
 router.get("/:creatorId/engagement-history", validateCreatorId, getEngagementHistory);

--- a/view/analytics-dashboard.ejs
+++ b/view/analytics-dashboard.ejs
@@ -13,6 +13,17 @@
                         <h1>Analytics Overview</h1>
                         <p>Track your audience growth and content performance.</p>
                     </div>
+                    <% if (typeof creators !== 'undefined' && creators.length > 1) { %>
+                    <div>
+                        <select id="accountSelector" class="badge-retro" style="cursor:pointer; border:2px solid var(--black); background:var(--white); padding:0.5rem; font-family:'Space Grotesk', monospace; font-size:0.9rem;">
+                            <% creators.forEach(creator => { %>
+                                <option value="<%= creator._id %>" <%= creator._id.toString() === selectedCreatorId ? 'selected' : '' %>>
+                                    <%= creator.username %> (<%= creator.platform %>)
+                                </option>
+                            <% }) %>
+                        </select>
+                    </div>
+                    <% } %>
                 </div>
 
                 <!-- Stats Grid -->
@@ -205,6 +216,17 @@
                         y: { grid: { color: chartGrid, drawBorder: false } }
                     }
                 }
+            });
+        }
+    </script>
+    <script>
+        const accountSelector = document.getElementById('accountSelector');
+        if (accountSelector) {
+            accountSelector.addEventListener('change', function() {
+                const creatorId = this.value;
+                const url = new URL(window.location);
+                url.searchParams.set('creatorId', creatorId);
+                window.location.href = url.toString();
             });
         }
     </script>


### PR DESCRIPTION
## Summary
Fixes analytics dashboard showing stale data after switching accounts. Previously, the user had to manually refresh the page to see the new account's data.

## Changes
- `controller/analytics.js` — Added `getCreatorsByUser` endpoint returning all creator accounts owned by the user
- `routes/analytics.js` — Added `GET /api/analytics/creators` route
- `index.js` — Pass `creatorId` query param to the analytics view, fetch creators list for the view
- `view/analytics-dashboard.ejs` — Added account selector dropdown, page reload on account switch

Closes #707