### PR TITLE
fix: validate reset token on page load

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -390,8 +390,41 @@ router.post("/forgot-password", forgotPasswordLimiter, requestPasswordReset);
  *       200:
  *         description: Successful response
  */
-router.get("/reset-password", (req, res) => {
-    res.render("reset-password", { token: req.query.token, error: null });
+router.get("/reset-password", async (req, res) => {
+    const token = req.query.token;
+
+    if (!token) {
+        return res.render("reset-password", {
+            token: null,
+            error: "No reset token provided.",
+            formHidden: true,
+        });
+    }
+
+    try {
+        await connectDB();
+        const User = require("../model/user");
+        const user = await User.findOne({
+            resetPasswordToken: token,
+            resetPasswordExpires: { $gt: Date.now() },
+        });
+
+        if (!user) {
+            return res.render("reset-password", {
+                token: null,
+                error: "This reset link is invalid, expired, or has already been used. Please request a new one.",
+                formHidden: true,
+            });
+        }
+
+        res.render("reset-password", { token, error: null, formHidden: false });
+    } catch (err) {
+        res.render("reset-password", {
+            token: null,
+            error: "Something went wrong. Please try again later.",
+            formHidden: true,
+        });
+    }
 });
 
 /**

--- a/view/reset-password.ejs
+++ b/view/reset-password.ejs
@@ -111,9 +111,14 @@
     <div class="container">
         <div class="header">
             <h1>Reset Password</h1>
-            <p>Enter your new password below.</p>
+            <% if (error) { %>
+                <p style="color: #991b1b; font-weight: 600;"><%= error %></p>
+            <% } else { %>
+                <p>Enter your new password below.</p>
+            <% } %>
         </div>
 
+        <% if (!formHidden) { %>
         <form id="resetForm">
             <input type="hidden" id="token" value="<%= token %>">
             <div class="form-group">
@@ -122,6 +127,7 @@
             </div>
             <button type="submit" class="btn" id="submitBtn">Update Password</button>
         </form>
+        <% } %>
         <div id="message"></div>
         <div style="text-align: center; margin-top: 1.5rem;">
             <a href="/login" style="color: var(--black); font-weight: 600;">Back to Login</a>


### PR DESCRIPTION
## Summary
Fixes the password reset flow to validate the reset token on page load. Previously, users could access expired or already-used tokens and only saw an error on submit.

## Changes
- `routes/auth.js` — Updated `GET /reset-password` to validate token against DB before rendering. Checks token existence and expiry (`resetPasswordExpires > now`)
- `view/reset-password.ejs` — Conditionally shows error message and hides form when token is invalid, expired, or already used

Closes #711