### PR TITLE
fix(bio): invalidate profile cache on bio save

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const passport = require("passport");
 const path = require('path');
 const rateLimit = require('express-rate-limit');
 const cacheHeadersMiddleware = require('./middleware/cacheHeaders');
-const { getProfileFromCache, setProfileInCache } = require('./utils/profileCache');
+const { getProfileFromCache, setProfileInCache, invalidateProfileCache } = require('./utils/profileCache');
 
 // Validate required environment variables
 const requiredEnvVars = [
@@ -572,6 +572,8 @@ app.post('/bio/save', protect, asyncHandler(async (req, res) => {
         updateData,
         { new: true, upsert: true }
     );
+    
+    await invalidateProfileCache(userHandle);
     
     return res.json({ success: true, data: bioProfile });
 }));


### PR DESCRIPTION
## Summary
Invalidates profile cache after bio update so subsequent reads return fresh data

## Changes
- `index.js` — Imported `invalidateProfileCache` and called it after the bio save completes

Closes #799