### PR TITLE
fix(instagram): check cache before enforcing cooldown

### DIFF
--- a/controller/instagramController.js
+++ b/controller/instagramController.js
@@ -131,8 +131,6 @@ async function getInstagramProfile(req, res) {
     try {
         const username = validateUsername(req.query.username);
 
-        await assertLookupAllowed(req);
-
         const cacheKey = `ig:profile:${username}`;
         const cachedProfile = redis
             ? await redis.get(cacheKey)
@@ -144,6 +142,8 @@ async function getInstagramProfile(req, res) {
                 data: JSON.parse(cachedProfile),
             });
         }
+
+        await assertLookupAllowed(req);
 
         const profile = await fetchInstagramProfile(username);
 


### PR DESCRIPTION
## Summary
Moves cooldown rate-limit check after cache lookup so cached responses are not rejected

## Changes
- `controller/instagramController.js` — Reordered so cache is checked first; `assertLookupAllowed` cooldown only applies when a fresh API call is actually needed

Closes #800