### PR TITLE
refactor(security): Increase bcrypt saltRounds to 12

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -218,7 +218,7 @@ const signup = asyncHandler(async (req, res, next) => {
         return res.status(409).json({ success: false, message: "User already exists" });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await bcrypt.hash(password, 12);
     const verificationToken = generateVerificationToken();
     const verificationTokenExpiry = getVerificationTokenExpiry();
 
@@ -765,7 +765,7 @@ const resetPassword = asyncHandler(async (req, res) => {
     }
 
     try {
-        const hashedPassword = await bcrypt.hash(newPassword, 10);
+        const hashedPassword = await bcrypt.hash(newPassword, 12);
         user.password = hashedPassword;
         user.passwordChangedAt = new Date();
         await user.save();

--- a/model/user.js
+++ b/model/user.js
@@ -294,7 +294,7 @@ const bcrypt = require("bcryptjs");
 (async () => {
     let hashed;
     try {
-        hashed = await bcrypt.hash("Password123!", 10);
+        hashed = await bcrypt.hash("Password123!", 12);
     } catch (e) {
         hashed = "hashed_password"; // fallback
     }

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -188,7 +188,7 @@ router.put('/security/password', preventContributorWrites, asyncHandler(async (r
         return res.status(400).json({ error: 'New password must be at least 8 characters.' });
     }
 
-    const salt = await bcrypt.genSalt(10);
+    const salt = await bcrypt.genSalt(12);
     user.password = await bcrypt.hash(newPassword, salt);
     user.passwordChangedAt = new Date();
     await user.save();

--- a/scripts/seedTestUser.js
+++ b/scripts/seedTestUser.js
@@ -23,7 +23,7 @@ async function seed() {
       process.exit(0);
     }
 
-    const hashed = await bcrypt.hash(password, 10);
+    const hashed = await bcrypt.hash(password, 12);
     const user = new User({ name: 'Test User', email, password: hashed });
     await user.save();
 

--- a/tests/controllers/auth.test.js
+++ b/tests/controllers/auth.test.js
@@ -11,7 +11,7 @@ describe('Auth Controller Endpoints', () => {
     beforeEach(async () => {
         await User.deleteMany({});
 
-        const verifiedPassword = await bcrypt.hash('Password123!', 10);
+        const verifiedPassword = await bcrypt.hash('Password123!', 12);
         await User.create({
             name: 'Verified User',
             email: 'test@local.com',
@@ -19,7 +19,7 @@ describe('Auth Controller Endpoints', () => {
             isVerified: true,
         });
 
-        const unverifiedPassword = await bcrypt.hash('Password123!', 10);
+        const unverifiedPassword = await bcrypt.hash('Password123!', 12);
         await User.create({
             name: 'Unverified User',
             email: 'unverified@local.com',

--- a/tests/controllers/authSecurity.test.js
+++ b/tests/controllers/authSecurity.test.js
@@ -43,7 +43,7 @@ describe('Bulletproof Auth & Security Tests (#597)', () => {
         });
 
         it('should prevent duplicate registration with the same normalized email', async () => {
-            const hashedPassword = await bcrypt.hash('Password123!', 10);
+            const hashedPassword = await bcrypt.hash('Password123!', 12);
             await User.create({
                 name: 'Existing User',
                 email: 'duplicate@example.com',
@@ -67,7 +67,7 @@ describe('Bulletproof Auth & Security Tests (#597)', () => {
 
     describe('Login Security & Timing Mitigation', () => {
         beforeEach(async () => {
-            const passwordHash = await bcrypt.hash('SecretPass123!', 10);
+            const passwordHash = await bcrypt.hash('SecretPass123!', 12);
             await User.create({
                 name: 'Valid User',
                 email: 'valid@example.com',

--- a/tests/controllers/collaboration.test.js
+++ b/tests/controllers/collaboration.test.js
@@ -15,7 +15,7 @@ describe('Collaboration Controller Endpoints', () => {
 
     beforeAll(async () => {
         await User.deleteMany({});
-        const password = await bcrypt.hash('Password123!', 10);
+        const password = await bcrypt.hash('Password123!', 12);
         await User.create({
             name: 'Verified User',
             email: 'test@local.com',

--- a/tests/controllers/url.test.js
+++ b/tests/controllers/url.test.js
@@ -11,7 +11,7 @@ describe('URL Controller Endpoints', () => {
 
     beforeAll(async () => {
         await User.deleteMany({});
-        const password = await bcrypt.hash('Password123!', 10);
+        const password = await bcrypt.hash('Password123!', 12);
         await User.create({
             name: 'Verified User',
             email: 'test@local.com',


### PR DESCRIPTION
Resolves #782. Upgrades bcrypt hashing and salt generation to use 12 rounds instead of 10 for better security.