### PR TITLE
docs: replace local file:/// links with repo-relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ CreatorOS uses a **Custom JWT Authentication System** (via HTTP-only cookie or B
 - **Primary Auth**: Requires `JWT_SECRET` and `SESSION_SECRET`.
 - **Google SSO**: Optional via `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_CALLBACK_URL`.
 
-For full details on authentication flows, token handling, and role-based access control, see [Authentication Documentation (`docs/AUTH.md`)](file:///d:/GSSoC/CreatorOs/CreatorOs/docs/AUTH.md).
+For full details on authentication flows, token handling, and role-based access control, see [Authentication Documentation (`docs/AUTH.md`)](docs/AUTH.md).
 
 ### Instagram Profile Fetching
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -88,7 +88,7 @@ sequenceDiagram
 
 ## 4. Token Resolution & Middleware Security
 
-Authentication checks are handled primarily by [`middleware/auth.js`](file:///d:/GSSoC/CreatorOs/CreatorOs/middleware/auth.js).
+Authentication checks are handled primarily by [`middleware/auth.js`](../middleware/auth.js).
 
 ### Token Resolution Strategy
 1. **Cookie Priority**: Reads `req.cookies.token` (httpOnly cookie).
@@ -102,7 +102,7 @@ Authentication checks are handled primarily by [`middleware/auth.js`](file:///d:
 
 ## 5. Role-Based Access Control (RBAC)
 
-CreatorOS supports four primary roles enforced by dedicated middleware functions in [`middleware/auth.js`](file:///d:/GSSoC/CreatorOs/CreatorOs/middleware/auth.js):
+CreatorOS supports four primary roles enforced by dedicated middleware functions in [`middleware/auth.js`](../middleware/auth.js):
 
 | Role | Description | Permissions & Restrictions |
 | :--- | :--- | :--- |


### PR DESCRIPTION
README and AUTH.md pointed at a machine-local file:///d:/GSSoC/... path that breaks for other contributors.
Use repo-relative links instead.
