### PR TITLE
docs: point CONTRIBUTING useful docs at existing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,10 +292,10 @@ Real-world use cases:
 ## 📚 Resources
 
 ### Useful Docs
-- [Project Architecture](./ARCHITECTURE.md)
-- [API Documentation](./API.md)
-- [Automation Guide](./ AUTOMATION.md)
-- [Deployment Guide](./DEPLOYMENT.md)
+- [Authentication](./docs/AUTH.md)
+- [Async Error Handling](./docs/ASYNC_ERROR_HANDLING.md)
+- [Email Verification](./docs/EMAIL_VERIFICATION.md)
+- [Nginx Load Balancing](./NGINX_LOAD_BALANCING.md)
 
 ### Learning Resources
 - [GitHub Guides](https://guides.github.com/)


### PR DESCRIPTION
Useful Docs linked to missing ARCHITECTURE/API/AUTOMATION/DEPLOYMENT files, including a broken ./ AUTOMATION.md path.
Point the list at guides that exist in the repository.
