### PR TITLE
ci: clarify merge-conflict notification comment

### DIFF
--- a/.github/workflows/notify-pr-conflicts.yml
+++ b/.github/workflows/notify-pr-conflicts.yml
@@ -77,7 +77,7 @@ jobs:
                         owner,
                         repo,
                         issue_number: pr.number,
-                        body: `@${author}, please resolve the commit so that it will be merged soon ......`
+                        body: `@${author}, this pull request has merge conflicts. Please rebase or merge the latest base branch and resolve the conflicts so it can be merged.`
                       });
                       console.log(`Posted merge conflict comment on PR #${pr.number}`);
                     } catch (e) {


### PR DESCRIPTION
The conflict bot asked contributors to resolve the commit, which is unclear.
Ask them to rebase or merge the base branch and resolve conflicts instead.
